### PR TITLE
ci: run only on pull_request, drop push-to-main trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
# TLDR;

Remove the `push: branches: [main]` trigger from `.github/workflows/ci.yml` so CI runs only on pull requests.

# What Was Changed

`.github/workflows/ci.yml` — deleted the `push` trigger block. The remaining `pull_request: branches: [main]` trigger is the only one left.

# Why

Every merge into main was firing CI twice — once on the PR head, then again on the resulting push to main. The post-merge run added no extra signal (same commits, same workflow) and burned a runner per merge. PR-only is enough.

# How Tests Prove It Works

This is a workflow trigger config change — no code or test paths exercised. After merge, observe that pushing to main no longer kicks off a CI run, but opening or updating a PR still does.

# Spec / Doc Changes

None.

# Breaking Changes

None at the code level. Operationally: anything that relied on CI logs from post-merge `push` events (e.g. dashboards filtering by `event=push` on `main`) needs to switch to the PR-event run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)