### PR TITLE
release: upgrade npm to >= 11.5 for Trusted Publisher OIDC auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: too-many-cooks/package-lock.json
 
+      - name: Upgrade npm to >= 11.5 (Trusted Publisher OIDC auth)
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         working-directory: too-many-cooks
         run: npm ci


### PR DESCRIPTION
# TLDR;

Add a step that runs \`npm install -g npm@latest\` before \`npm publish\`. Unblocks tagged releases.

# Why the publishes have been failing

Every release since v0.9.0 has failed at \`Publish too-many-cooks-core to npm\` with:

\`\`\`
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: ...
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/too-many-cooks-core - Not found
npm error 404  'too-many-cooks-core@X.Y.Z' is not in this registry.
\`\`\`

Trusted Publisher config on npmjs.org is fine (verified). The bug is the **npm client version**:

- The workflow uses Node 22, which ships with npm 10.x.
- npm 10.x supports \`--provenance\` (OIDC for sigstore signing) but does **not** support OIDC-based authentication when publishing to a Trusted Publisher.
- Result: provenance gets signed, then the PUT goes out with no auth, and npm returns 404 (which is how npm reports unauth'd writes to hide package existence).
- OIDC publishing auth landed in npm CLI 11.5.

# The change

\`\`\`yaml
- name: Upgrade npm to >= 11.5 (Trusted Publisher OIDC auth)
  run: npm install -g npm@latest
\`\`\`

Added between \`Setup Node.js\` and \`Install dependencies\` so every subsequent \`npm\` call (including \`npm publish\`) runs against 11.x.

# How to verify

After merging, the next git tag push (or a re-run of the v0.11.0 release run) should:
1. Still emit the provenance + transparency log lines.
2. Then complete the PUT to npm successfully — \`too-many-cooks-core@0.11.0\` and \`too-many-cooks@0.11.0\` appear on npmjs.com.

# Breaking Changes

None. Only the release workflow changes; runtime artifacts (the published packages) are unchanged.