### PR TITLE
Fix npm publish + auto-publish VSIX to VS Code Marketplace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,17 @@ jobs:
           npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version --allow-same-version
           npx vsce package --no-git-tag-version ${{ steps.version.outputs.VERSION }}
 
+      - name: Publish VSIX to VS Code Marketplace
+        working-directory: too_many_cooks_vscode_extension
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "::warning::VSCE_PAT secret not set — skipping VS Code Marketplace publish. Add it under repo Settings → Secrets and variables → Actions to enable."
+            exit 0
+          fi
+          npx vsce publish --packagePath too-many-cooks-${{ steps.version.outputs.VERSION }}.vsix --pat "$VSCE_PAT"
+
       - name: Upload VSIX as release asset
         uses: softprops/action-gh-release@v2
         with:

--- a/too-many-cooks/packages/too-many-cooks/package.json
+++ b/too-many-cooks/packages/too-many-cooks/package.json
@@ -14,6 +14,11 @@
     "README.md",
     "LICENSE"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Nimblesite/too-many-cooks",
+    "directory": "too-many-cooks/packages/too-many-cooks"
+  },
   "scripts": {
     "build": "tsc",
     "start": "node build/bin/server.js",


### PR DESCRIPTION
# TLDR;

Two release-pipeline fixes:
1. Add `repository` field to `too-many-cooks/packages/too-many-cooks/package.json` so npm's sigstore provenance verification accepts the publish.
2. Add `vsce publish` step to the `build-vsix` job so every tagged release auto-publishes the VSIX to the VS Code Marketplace.

# Why

**Fix 1 — npm E422.** v0.11.2 finally got past the OIDC auth wall (Trusted Publisher works now) and was rejected at the next gate:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/too-many-cooks - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/Nimblesite/too-many-cooks" from provenance
```

`too-many-cooks-core` already has `repository` set (that's why it publishes); `too-many-cooks` doesn't.

**Fix 2 — marketplace auto-publish.** The workflow built the VSIX and attached it to the GitHub Release, but never pushed to the VS Code Marketplace. New step uses `npx vsce publish` and is **gracefully gated** on the `VSCE_PAT` secret — if not set, the step prints a warning and exits 0 (no false failure).

# What you need to do once

To enable marketplace publishing:
1. Create a Personal Access Token in Azure DevOps with **Marketplace > Manage** scope: https://dev.azure.com → User settings → Personal access tokens.
2. Add it as repo secret `VSCE_PAT` (Settings → Secrets and variables → Actions → New repository secret).

Until you do, releases still ship npm + GitHub Release VSIX as before; the marketplace step just no-ops.

# Breaking Changes

None.