### PR TITLE
release: use VSCODE_MARKETPLACE_PAT (the org secret that actually exists)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,13 +129,13 @@ jobs:
       - name: Publish VSIX to VS Code Marketplace
         working-directory: too_many_cooks_vscode_extension
         env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          VSCE_PAT: ${{ secrets.VSCODE_MARKETPLACE_PAT }}
         run: |
           if [ -z "$VSCE_PAT" ]; then
-            echo "::warning::VSCE_PAT secret not set — skipping VS Code Marketplace publish. Add it under repo Settings → Secrets and variables → Actions to enable."
-            exit 0
+            echo "::error::VSCODE_MARKETPLACE_PAT not accessible. If it exists at the Nimblesite org level, add too-many-cooks to its allowed repositories under Org Settings → Secrets and variables → Actions."
+            exit 1
           fi
-          npx vsce publish --packagePath too-many-cooks-${{ steps.version.outputs.VERSION }}.vsix --pat "$VSCE_PAT"
+          npx --yes @vscode/vsce publish --packagePath too-many-cooks-${{ steps.version.outputs.VERSION }}.vsix
 
       - name: Upload VSIX as release asset
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
# TLDR;

Switch the VSIX marketplace publish step from \`secrets.VSCE_PAT\` (doesn't exist) to \`secrets.VSCODE_MARKETPLACE_PAT\` (Nimblesite org-level secret already used by Nimblesite/Basilisk). Also makes the step hard-fail if the secret can't be resolved, so a missing-PAT never silently skips the marketplace upload again.

# How I found this

Searched every Nimblesite repo. Only one workflow actually invokes \`vsce publish\` against the marketplace: [Nimblesite/Basilisk/.github/workflows/release.yml](https://github.com/Nimblesite/Basilisk/blob/main/.github/workflows/release.yml#L353):

\`\`\`yaml
npx --yes @vscode/vsce publish $flag --packagePath $(find . -iname '*.vsix')
env:
  VSCE_PAT: \${{ secrets.VSCODE_MARKETPLACE_PAT }}
\`\`\`

Basilisk's most recent run logs show \`VSCE_PAT: ***\` resolving to a non-empty value (failure there was a prerelease-version policy issue, not auth). So the org secret exists and works in at least one repo.

# Risk

If \`VSCODE_MARKETPLACE_PAT\` is org-scoped with restricted repo access, too-many-cooks may not be in the allowlist. In that case the new step still hard-fails with a clear error pointing at \`Org Settings → Secrets and variables → Actions\` to add this repo. Easy fix from the org admin UI.

# Breaking Changes

None.