### PR TITLE
Bump better-sqlite3 to ^12.10.0 — fix Node 22 ABI mismatch

### DIFF
--- a/too-many-cooks/package-lock.json
+++ b/too-many-cooks/package-lock.json
@@ -1894,9 +1894,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.5.0.tgz",
-      "integrity": "sha512-WwCZ/5Diz7rsF29o27o0Gcc1Du+l7Zsv7SYtVPG0X3G/uUI1LqdxrQI7c9Hs2FWpqXXERjW9hp6g3/tH7DlVKg==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1904,7 +1904,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {
@@ -5245,7 +5245,7 @@
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "better-sqlite3": "^12.5.0",
+        "better-sqlite3": "^12.10.0",
         "prisma": "^7.5.0",
         "too-many-cooks-core": "*"
       },

--- a/too-many-cooks/packages/too-many-cooks/package.json
+++ b/too-many-cooks/packages/too-many-cooks/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "too-many-cooks-core": "*",
-    "better-sqlite3": "^12.5.0",
+    "better-sqlite3": "^12.10.0",
     "prisma": "^7.5.0"
   },
   "devDependencies": {

--- a/too-many-cooks/packages/too-many-cooks/test/published_package_e2e_test.ts
+++ b/too-many-cooks/packages/too-many-cooks/test/published_package_e2e_test.ts
@@ -121,10 +121,24 @@ const packTarball = (): string => {
 
 const installTarball = (tarball: string): string => {
   const dir: string = mkdtempSync(join(tmpdir(), INSTALL_PREFIX));
+  // Isolated npm cache so the resolver MUST go to the registry. With the
+  // shared system cache, `--prefer-offline` (or even default behaviour after
+  // a stale cache) can resurrect old transitive versions whose native
+  // prebuilds don't match the current Node ABI — that's the failure mode
+  // that bit `npx too-many-cooks` in the wild. A fresh cache reproduces a
+  // first-time user's resolve.
+  const cacheDir: string = mkdtempSync(join(tmpdir(), "tmc-pubpkg-cache-"));
   execFileSync("npm", ["init", "-y"], { cwd: dir, stdio: "pipe" });
   execFileSync(
     "npm",
-    ["install", "--no-audit", "--no-fund", "--prefer-offline", tarball],
+    [
+      "install",
+      "--no-audit",
+      "--no-fund",
+      "--prefer-online",
+      `--cache=${cacheDir}`,
+      tarball,
+    ],
     { cwd: dir, stdio: "pipe" },
   );
   return dir;


### PR DESCRIPTION
# TLDR;

`npx too-many-cooks` on a fresh Node 22 machine crashes with `NODE_MODULE_VERSION 115 vs 127` because better-sqlite3 12.5.0 (what `^12.5.0` resolved to) ships no Node 22 prebuild. Bump to `^12.10.0`. Also fix the E2E test that masked this — it was using `--prefer-offline` against the system npm cache, so it never reproduced what a first-time user actually sees.

# What Was Changed

- `packages/too-many-cooks/package.json`: `better-sqlite3` `^12.5.0` → `^12.10.0`.
- `test/published_package_e2e_test.ts`: install step now uses `--prefer-online --cache=<mkdtemp>` so the resolver hits the registry every time. The old `--prefer-offline` against the shared cache could resurrect old transitive versions whose prebuilds don't match the current Node ABI.

# How Tests Prove It Works

- E2E suite (9/9) passes with the fresh isolated cache.
- Verified manually: `npm install better-sqlite3@12.10.0` then `require('better-sqlite3')(':memory:')` works on Node 22.22.2 (NODE_MODULE_VERSION 127). 12.5.0 picks the wrong ABI on the same Node.

# Breaking Changes

None.