### PR TITLE
Cascade-delete referential integrity + multi-select tree commands

### DIFF
--- a/too-many-cooks/packages/too-many-cooks/prisma/migrations/20260525000000_add_to_agent_fk_cascade/migration.sql
+++ b/too-many-cooks/packages/too-many-cooks/prisma/migrations/20260525000000_add_to_agent_fk_cascade/migration.sql
@@ -1,0 +1,23 @@
+-- Adds a foreign key on messages.to_agent → identity.agent_name with
+-- ON DELETE CASCADE so deleting an agent removes inbound messages too.
+-- Previously only from_agent had a FK, which left orphaned messages
+-- whenever the recipient was deleted.
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_messages" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "from_agent" TEXT NOT NULL,
+    "to_agent" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "created_at" BIGINT NOT NULL,
+    "read_at" BIGINT,
+    CONSTRAINT "messages_from_agent_fkey" FOREIGN KEY ("from_agent") REFERENCES "identity" ("agent_name") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "messages_to_agent_fkey" FOREIGN KEY ("to_agent") REFERENCES "identity" ("agent_name") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_messages" ("content", "created_at", "from_agent", "id", "read_at", "to_agent") SELECT "content", "created_at", "from_agent", "id", "read_at", "to_agent" FROM "messages";
+DROP TABLE "messages";
+ALTER TABLE "new_messages" RENAME TO "messages";
+CREATE INDEX "idx_messages_inbox" ON "messages"("to_agent", "read_at", "created_at" DESC);
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/too-many-cooks/packages/too-many-cooks/prisma/schema.prisma
+++ b/too-many-cooks/packages/too-many-cooks/prisma/schema.prisma
@@ -14,10 +14,11 @@ model Identity {
   registeredAt BigInt  @map("registered_at")
   lastActive   BigInt  @map("last_active")
 
-  locks        Lock[]
-  messages     Message[]
-  messageReads MessageRead[]
-  plans        Plan[]
+  locks            Lock[]
+  messagesSent     Message[]     @relation("MessageFrom")
+  messagesReceived Message[]     @relation("MessageTo")
+  messageReads     MessageRead[]
+  plans            Plan[]
 
   @@map("identity")
 }
@@ -43,7 +44,8 @@ model Message {
   createdAt BigInt  @map("created_at")
   readAt    BigInt? @map("read_at")
 
-  identity     Identity      @relation(fields: [fromAgent], references: [agentName], onDelete: Cascade)
+  from         Identity      @relation("MessageFrom", fields: [fromAgent], references: [agentName], onDelete: Cascade)
+  to           Identity      @relation("MessageTo",   fields: [toAgent],   references: [agentName], onDelete: Cascade)
   messageReads MessageRead[]
 
   @@index([toAgent, readAt, createdAt(sort: Desc)], map: "idx_messages_inbox")

--- a/too-many-cooks/packages/too-many-cooks/src/db-sqlite.ts
+++ b/too-many-cooks/packages/too-many-cooks/src/db-sqlite.ts
@@ -56,8 +56,23 @@ const ACTIVE_TRUE: number = 1;
 /** Inactive flag value. */
 const ACTIVE_FALSE: number = 0;
 
-/** Broadcast recipient marker. */
+/** Broadcast recipient marker. Also the reserved agent_name of the sentinel
+ *  identity row that lets the messages.to_agent foreign key target broadcasts
+ *  without orphaning them. The sentinel is created with active=0 so
+ *  listAgents (which filters by active=1) never surfaces it in the UI. */
 const BROADCAST_RECIPIENT: string = "*";
+
+/** Insert the reserved '*' identity row required by the messages.to_agent FK
+ *  for broadcasts. Idempotent — re-runs on every DB open are safe. The row
+ *  is kept active=0 so it never appears in agent listings. */
+const seedBroadcastSentinel: (db: Database.Database) => void = (
+  db: Database.Database,
+): void => {
+  const timestamp: number = now();
+  db.prepare(
+    "INSERT OR IGNORE INTO identity (agent_name, agent_key, active, registered_at, last_active) VALUES (?, ?, 0, ?, ?)",
+  ).run(BROADCAST_RECIPIENT, `__broadcast_sentinel_${generateKey()}`, timestamp, timestamp);
+};
 
 /** SQLite-specific retryable errors. */
 const isSqliteRetryable: (err: string) => boolean = (err: string): boolean =>
@@ -136,6 +151,7 @@ const openAndInit: (
   try {
     db = new Database(config.dbPath);
     db.pragma("foreign_keys = ON");
+    seedBroadcastSentinel(db);
   } catch (e: unknown) {
     return error(`Failed to open database: ${String(e)}`);
   }
@@ -210,6 +226,10 @@ const register: (
   if (name.length < MIN_AGENT_NAME_LENGTH || name.length > MAX_AGENT_NAME_LENGTH) {
     log.warn("Registration failed: invalid name length");
     return error({ code: ERR_VALIDATION, message: "Name must be 1-50 chars" });
+  }
+  if (name === BROADCAST_RECIPIENT) {
+    log.warn("Registration failed: reserved broadcast name");
+    return error({ code: ERR_VALIDATION, message: "Name '*' is reserved for broadcasts" });
   }
   const key: string = generateKey();
   const timestamp: number = now();
@@ -905,14 +925,14 @@ const adminDeleteAgent: (
   agentName: string,
 ): Result<void, DbError> => {
   log.warn(`Admin deleting agent ${agentName}`);
+  if (agentName === BROADCAST_RECIPIENT) {
+    return error({ code: ERR_VALIDATION, message: "Cannot delete broadcast sentinel" });
+  }
   try {
-    // Delete child rows explicitly (in FK-safe order) before deleting the identity row.
-    // Cascade is defined in the schema but must not be relied upon — explicit deletes
-    // are more reliable across SQLite versions and PRAGMA states.
-    db.prepare("DELETE FROM locks WHERE agent_name = ?").run(agentName);
-    db.prepare("DELETE FROM plans WHERE agent_name = ?").run(agentName);
-    db.prepare("DELETE FROM messages WHERE from_agent = ?").run(agentName);
-    db.prepare("DELETE FROM messages WHERE to_agent = ?").run(agentName);
+    // Cascade is enforced by the schema (locks, plans, messages.from_agent,
+    // messages.to_agent all ON DELETE CASCADE), so the single DELETE on
+    // identity removes every dependent row atomically. No manual fan-out —
+    // doing so would mask FK regressions.
     const result: Database.RunResult = db
       .prepare("DELETE FROM identity WHERE agent_name = ?")
       .run(agentName);
@@ -1014,9 +1034,17 @@ const adminSendMessage: (
   const timestamp: number = now();
   try {
     const ensureStmt: Database.Statement = db.prepare(
-      "INSERT OR IGNORE INTO identity (agent_name, agent_key, registered_at, last_active) VALUES (?, ?, ?, ?)",
+      "INSERT OR IGNORE INTO identity (agent_name, agent_key, active, registered_at, last_active) VALUES (?, ?, 0, ?, ?)",
     );
+    // Auto-create sender (existing behaviour) AND recipient so the to_agent
+    // FK is satisfied. '*' is skipped because the broadcast sentinel is
+    // seeded at DB open. Auto-created peers are inactive so they don't
+    // pollute agent listings; if they later register for real, the upsert
+    // in register() reactivates them.
     ensureStmt.run(fromAgent, generateKey(), timestamp, timestamp);
+    if (toAgent !== BROADCAST_RECIPIENT) {
+      ensureStmt.run(toAgent, generateKey(), timestamp, timestamp);
+    }
   } catch (e: unknown) {
     return error({ code: ERR_DATABASE, message: String(e) });
   }

--- a/too-many-cooks/packages/too-many-cooks/test/foreign_key_integrity_test.ts
+++ b/too-many-cooks/packages/too-many-cooks/test/foreign_key_integrity_test.ts
@@ -1,4 +1,8 @@
-/// Tests that SQLite foreign key constraints are enforced and cascade deletes work.
+/// Tests that SQLite foreign key constraints are enforced and cascade deletes
+/// work for every child table — locks, plans, AND messages (both directions).
+/// Originally only locks/plans/from_agent were covered, which let orphaned
+/// inbound messages survive after a recipient was deleted (visible in the
+/// VSIX as messages with no matching agent in the agents tree).
 
 import { describe, it, afterEach } from "node:test";
 import assert from "node:assert";
@@ -9,11 +13,18 @@ import { createDataConfig } from "too-many-cooks-core";
 import { createDb } from "../src/db-sqlite.js";
 
 const TEST_FK_DB_PATH = ".test_fk_integrity.db" as const;
+const BROADCAST: string = "*";
 
 const deleteIfExists = (path: string): void => {
   try {
     if (fs.existsSync(path)) { fs.unlinkSync(path); }
   } catch { /* ignore */ }
+};
+
+const openRawDb = (): Database.Database => {
+  const db = new Database(TEST_FK_DB_PATH);
+  db.pragma("foreign_keys = ON");
+  return db;
 };
 
 describe("foreign_key_integrity", () => {
@@ -33,8 +44,7 @@ describe("foreign_key_integrity", () => {
     await result.value.acquireLock("/fk/test.ts", reg.value.agentName, reg.value.agentKey, null, 60000);
     await result.value.close();
 
-    const db = new Database(TEST_FK_DB_PATH);
-    db.pragma("foreign_keys = ON");
+    const db = openRawDb();
     db.prepare("DELETE FROM identity WHERE agent_name = ?").run("fk-test-agent");
     const lockRow = db.prepare("SELECT * FROM locks WHERE agent_name = ?").get("fk-test-agent");
     db.close();
@@ -56,8 +66,7 @@ describe("foreign_key_integrity", () => {
     await result.value.updatePlan(reg.value.agentName, reg.value.agentKey, "Goal", "Task");
     await result.value.close();
 
-    const db = new Database(TEST_FK_DB_PATH);
-    db.pragma("foreign_keys = ON");
+    const db = openRawDb();
     db.prepare("DELETE FROM identity WHERE agent_name = ?").run("fk-plan-agent");
     const planRow = db.prepare("SELECT * FROM plans WHERE agent_name = ?").get("fk-plan-agent");
     db.close();
@@ -73,8 +82,7 @@ describe("foreign_key_integrity", () => {
     if (!result.ok) { return; }
     await result.value.close();
 
-    const db = new Database(TEST_FK_DB_PATH);
-    db.pragma("foreign_keys = ON");
+    const db = openRawDb();
     assert.throws(
       () => {
         db.prepare(
@@ -85,5 +93,211 @@ describe("foreign_key_integrity", () => {
       "Inserting a lock for a nonexistent agent must fail",
     );
     db.close();
+  });
+
+  it("cascade deletes outbound messages (from_agent) when sender is deleted", async () => {
+    deleteIfExists(TEST_FK_DB_PATH);
+    const config = createDataConfig({ dbPath: TEST_FK_DB_PATH });
+    const result = createDb(config);
+    assert.strictEqual(result.ok, true);
+    if (!result.ok) { return; }
+
+    const sender = await result.value.register("fk-msg-sender");
+    const receiver = await result.value.register("fk-msg-receiver");
+    assert.strictEqual(sender.ok, true);
+    assert.strictEqual(receiver.ok, true);
+    if (!sender.ok || !receiver.ok) { return; }
+
+    const sent = await result.value.sendMessage(
+      sender.value.agentName, sender.value.agentKey, receiver.value.agentName, "hi receiver",
+    );
+    assert.strictEqual(sent.ok, true);
+    await result.value.close();
+
+    const db = openRawDb();
+    const before = db.prepare("SELECT COUNT(*) as c FROM messages WHERE from_agent = ?").get("fk-msg-sender") as { c: number };
+    assert.strictEqual(before.c, 1, "Sanity: sender must have one outbound message before delete");
+
+    db.prepare("DELETE FROM identity WHERE agent_name = ?").run("fk-msg-sender");
+
+    const after = db.prepare("SELECT COUNT(*) as c FROM messages WHERE from_agent = ?").get("fk-msg-sender") as { c: number };
+    const receiverInbox = db.prepare("SELECT COUNT(*) as c FROM messages WHERE to_agent = ?").get("fk-msg-receiver") as { c: number };
+    db.close();
+
+    assert.strictEqual(after.c, 0, "Outbound messages from deleted sender must be cascade-deleted");
+    assert.strictEqual(receiverInbox.c, 0, "Receiver inbox referencing dead sender must be cleaned");
+  });
+
+  it("cascade deletes inbound messages (to_agent) when recipient is deleted — the bug the user reported", async () => {
+    deleteIfExists(TEST_FK_DB_PATH);
+    const config = createDataConfig({ dbPath: TEST_FK_DB_PATH });
+    const result = createDb(config);
+    assert.strictEqual(result.ok, true);
+    if (!result.ok) { return; }
+
+    const sender = await result.value.register("fk-survives-sender");
+    const recipient = await result.value.register("fk-doomed-recipient");
+    assert.strictEqual(sender.ok, true);
+    assert.strictEqual(recipient.ok, true);
+    if (!sender.ok || !recipient.ok) { return; }
+
+    const sent1 = await result.value.sendMessage(
+      sender.value.agentName, sender.value.agentKey, recipient.value.agentName, "msg 1",
+    );
+    const sent2 = await result.value.sendMessage(
+      sender.value.agentName, sender.value.agentKey, recipient.value.agentName, "msg 2",
+    );
+    assert.strictEqual(sent1.ok, true);
+    assert.strictEqual(sent2.ok, true);
+    await result.value.close();
+
+    const db = openRawDb();
+    const before = db.prepare("SELECT COUNT(*) as c FROM messages WHERE to_agent = ?").get("fk-doomed-recipient") as { c: number };
+    assert.strictEqual(before.c, 2, "Sanity: recipient must have two inbound messages before delete");
+
+    db.prepare("DELETE FROM identity WHERE agent_name = ?").run("fk-doomed-recipient");
+
+    const after = db.prepare("SELECT COUNT(*) as c FROM messages WHERE to_agent = ?").get("fk-doomed-recipient") as { c: number };
+    const senderStillThere = db.prepare("SELECT agent_name FROM identity WHERE agent_name = ?").get("fk-survives-sender") as { agent_name: string } | undefined;
+    db.close();
+
+    assert.strictEqual(after.c, 0, "Inbound messages to deleted recipient MUST be cascade-deleted — no orphans");
+    assert.notStrictEqual(senderStillThere, undefined, "Sender must survive deletion of recipient");
+  });
+
+  it("rejects message insertion for nonexistent to_agent when FKs enforced", async () => {
+    deleteIfExists(TEST_FK_DB_PATH);
+    const config = createDataConfig({ dbPath: TEST_FK_DB_PATH });
+    const result = createDb(config);
+    assert.strictEqual(result.ok, true);
+    if (!result.ok) { return; }
+
+    const sender = await result.value.register("fk-orphan-sender");
+    assert.strictEqual(sender.ok, true);
+    if (!sender.ok) { return; }
+    await result.value.close();
+
+    const db = openRawDb();
+    assert.throws(
+      () => {
+        db.prepare(
+          "INSERT INTO messages (id, from_agent, to_agent, content, created_at) VALUES (?, ?, ?, ?, ?)",
+        ).run("orphan-msg-id", "fk-orphan-sender", "ghost-recipient", "boom", Date.now());
+      },
+      /FOREIGN KEY constraint failed/u,
+      "Inserting a message to a nonexistent recipient must fail",
+    );
+    db.close();
+  });
+
+  it("broadcast sentinel row exists so to_agent='*' is FK-valid", async () => {
+    deleteIfExists(TEST_FK_DB_PATH);
+    const config = createDataConfig({ dbPath: TEST_FK_DB_PATH });
+    const result = createDb(config);
+    assert.strictEqual(result.ok, true);
+    if (!result.ok) { return; }
+
+    const sender = await result.value.register("fk-broadcast-sender");
+    assert.strictEqual(sender.ok, true);
+    if (!sender.ok) { return; }
+
+    const broadcast = await result.value.sendMessage(
+      sender.value.agentName, sender.value.agentKey, BROADCAST, "hello everyone",
+    );
+    assert.strictEqual(broadcast.ok, true, "Broadcast send must succeed thanks to '*' sentinel row");
+    await result.value.close();
+
+    const db = openRawDb();
+    const sentinel = db.prepare("SELECT agent_name, active FROM identity WHERE agent_name = ?").get(BROADCAST) as { agent_name: string; active: number } | undefined;
+    const broadcastRow = db.prepare("SELECT to_agent, content FROM messages WHERE to_agent = ?").get(BROADCAST) as { to_agent: string; content: string } | undefined;
+    db.close();
+
+    assert.notStrictEqual(sentinel, undefined, "Broadcast sentinel identity row must exist");
+    assert.strictEqual(sentinel?.active, 0, "Sentinel must be inactive so it never appears in agent lists");
+    assert.notStrictEqual(broadcastRow, undefined, "Broadcast message must be stored against to_agent='*'");
+    assert.strictEqual(broadcastRow?.content, "hello everyone");
+  });
+
+  it("register rejects '*' because it would collide with the broadcast sentinel", async () => {
+    deleteIfExists(TEST_FK_DB_PATH);
+    const config = createDataConfig({ dbPath: TEST_FK_DB_PATH });
+    const result = createDb(config);
+    assert.strictEqual(result.ok, true);
+    if (!result.ok) { return; }
+
+    const rejected = await result.value.register(BROADCAST);
+    await result.value.close();
+
+    assert.strictEqual(rejected.ok, false, "Registering '*' must be rejected");
+    if (rejected.ok) { return; }
+    assert.match(rejected.error.message, /reserved/i, "Error message must explain the reservation");
+  });
+
+  it("adminDeleteAgent refuses to delete the broadcast sentinel", async () => {
+    deleteIfExists(TEST_FK_DB_PATH);
+    const config = createDataConfig({ dbPath: TEST_FK_DB_PATH });
+    const result = createDb(config);
+    assert.strictEqual(result.ok, true);
+    if (!result.ok) { return; }
+
+    const refused = await result.value.adminDeleteAgent(BROADCAST);
+    assert.strictEqual(refused.ok, false, "adminDeleteAgent must refuse to delete the sentinel");
+
+    const sender = await result.value.register("fk-still-broadcasting");
+    assert.strictEqual(sender.ok, true);
+    if (!sender.ok) { return; }
+    const broadcast = await result.value.sendMessage(
+      sender.value.agentName, sender.value.agentKey, BROADCAST, "still works",
+    );
+    await result.value.close();
+
+    assert.strictEqual(broadcast.ok, true, "Broadcast must still work after refused delete attempt");
+  });
+
+  it("cascade is end-to-end: adminDeleteAgent wipes locks, plans, outbound AND inbound messages", async () => {
+    deleteIfExists(TEST_FK_DB_PATH);
+    const config = createDataConfig({ dbPath: TEST_FK_DB_PATH });
+    const result = createDb(config);
+    assert.strictEqual(result.ok, true);
+    if (!result.ok) { return; }
+
+    const alice = await result.value.register("fk-alice");
+    const bob = await result.value.register("fk-bob");
+    assert.strictEqual(alice.ok, true);
+    assert.strictEqual(bob.ok, true);
+    if (!alice.ok || !bob.ok) { return; }
+
+    await result.value.acquireLock("/a.ts", alice.value.agentName, alice.value.agentKey, "edit", 60000);
+    await result.value.acquireLock("/b.ts", alice.value.agentName, alice.value.agentKey, "edit", 60000);
+    await result.value.updatePlan(alice.value.agentName, alice.value.agentKey, "Goal", "Task");
+    await result.value.sendMessage(alice.value.agentName, alice.value.agentKey, bob.value.agentName, "out 1");
+    await result.value.sendMessage(alice.value.agentName, alice.value.agentKey, bob.value.agentName, "out 2");
+    await result.value.sendMessage(bob.value.agentName, bob.value.agentKey, alice.value.agentName, "in 1");
+    await result.value.sendMessage(alice.value.agentName, alice.value.agentKey, BROADCAST, "shout");
+
+    const wipe = await result.value.adminDeleteAgent("fk-alice");
+    assert.strictEqual(wipe.ok, true, "adminDeleteAgent must succeed");
+
+    const locksAfter = await result.value.listLocks();
+    const plansAfter = await result.value.listPlans();
+    const messagesAfter = await result.value.listAllMessages();
+    const agentsAfter = await result.value.listAgents();
+    await result.value.close();
+
+    assert.strictEqual(locksAfter.ok, true);
+    assert.strictEqual(plansAfter.ok, true);
+    assert.strictEqual(messagesAfter.ok, true);
+    assert.strictEqual(agentsAfter.ok, true);
+    if (!locksAfter.ok || !plansAfter.ok || !messagesAfter.ok || !agentsAfter.ok) { return; }
+
+    assert.strictEqual(locksAfter.value.length, 0, "All of alice's locks must be gone");
+    assert.strictEqual(plansAfter.value.length, 0, "Alice's plan must be gone");
+    const aliceMessages = messagesAfter.value.filter(
+      (m) => m.fromAgent === "fk-alice" || m.toAgent === "fk-alice",
+    );
+    assert.strictEqual(aliceMessages.length, 0, "Every message touching alice (from OR to) must be gone");
+    assert.strictEqual(messagesAfter.value.length, 0, "All four cross-agent messages must cascade out");
+    assert.strictEqual(agentsAfter.value.length, 1, "Only bob remains as an active agent");
+    assert.strictEqual(agentsAfter.value[0]?.agentName, "fk-bob");
   });
 });

--- a/too-many-cooks/packages/too-many-cooks/test/foreign_key_integrity_test.ts
+++ b/too-many-cooks/packages/too-many-cooks/test/foreign_key_integrity_test.ts
@@ -158,7 +158,7 @@ describe("foreign_key_integrity", () => {
     db.prepare("DELETE FROM identity WHERE agent_name = ?").run("fk-doomed-recipient");
 
     const after = db.prepare("SELECT COUNT(*) as c FROM messages WHERE to_agent = ?").get("fk-doomed-recipient") as { c: number };
-    const senderStillThere = db.prepare("SELECT agent_name FROM identity WHERE agent_name = ?").get("fk-survives-sender") as { agent_name: string } | undefined;
+    const senderStillThere: unknown = db.prepare("SELECT agent_name FROM identity WHERE agent_name = ?").get("fk-survives-sender");
     db.close();
 
     assert.strictEqual(after.c, 0, "Inbound messages to deleted recipient MUST be cascade-deleted — no orphans");
@@ -208,8 +208,8 @@ describe("foreign_key_integrity", () => {
     await result.value.close();
 
     const db = openRawDb();
-    const sentinel = db.prepare("SELECT agent_name, active FROM identity WHERE agent_name = ?").get(BROADCAST) as { agent_name: string; active: number } | undefined;
-    const broadcastRow = db.prepare("SELECT to_agent, content FROM messages WHERE to_agent = ?").get(BROADCAST) as { to_agent: string; content: string } | undefined;
+    const sentinel = db.prepare("SELECT agent_name AS agentName, active FROM identity WHERE agent_name = ?").get(BROADCAST) as { agentName: string; active: number } | undefined;
+    const broadcastRow = db.prepare("SELECT to_agent AS toAgent, content FROM messages WHERE to_agent = ?").get(BROADCAST) as { toAgent: string; content: string } | undefined;
     db.close();
 
     assert.notStrictEqual(sentinel, undefined, "Broadcast sentinel identity row must exist");
@@ -230,7 +230,7 @@ describe("foreign_key_integrity", () => {
 
     assert.strictEqual(rejected.ok, false, "Registering '*' must be rejected");
     if (rejected.ok) { return; }
-    assert.match(rejected.error.message, /reserved/i, "Error message must explain the reservation");
+    assert.match(rejected.error.message, /reserved/iu, "Error message must explain the reservation");
   });
 
   it("adminDeleteAgent refuses to delete the broadcast sentinel", async () => {

--- a/too_many_cooks_vscode_extension/package.json
+++ b/too_many_cooks_vscode_extension/package.json
@@ -83,6 +83,41 @@
         "title": "Remove All Agents",
         "category": "Too Many Cooks",
         "icon": "$(clear-all)"
+      },
+      {
+        "command": "tooManyCooks.copyMessageContent",
+        "title": "Copy Message Content",
+        "category": "Too Many Cooks"
+      },
+      {
+        "command": "tooManyCooks.copyMessageAsQuote",
+        "title": "Copy as Quoted Line",
+        "category": "Too Many Cooks"
+      },
+      {
+        "command": "tooManyCooks.copyMessageId",
+        "title": "Copy Message ID",
+        "category": "Too Many Cooks"
+      },
+      {
+        "command": "tooManyCooks.copyMessageSender",
+        "title": "Copy Sender",
+        "category": "Too Many Cooks"
+      },
+      {
+        "command": "tooManyCooks.copyMessageRecipient",
+        "title": "Copy Recipient",
+        "category": "Too Many Cooks"
+      },
+      {
+        "command": "tooManyCooks.copyMessages",
+        "title": "Copy Selected Messages (Full)",
+        "category": "Too Many Cooks"
+      },
+      {
+        "command": "tooManyCooks.copyAgentName",
+        "title": "Copy Agent Name",
+        "category": "Too Many Cooks"
       }
     ],
     "viewsContainers": {
@@ -148,6 +183,51 @@
           "command": "tooManyCooks.sendMessage",
           "when": "view == tooManyCooksAgents && viewItem == deletableAgent",
           "group": "inline"
+        },
+        {
+          "command": "tooManyCooks.copyAgentName",
+          "when": "view == tooManyCooksAgents && viewItem == deletableAgent",
+          "group": "1_copy@1"
+        },
+        {
+          "command": "tooManyCooks.sendMessage",
+          "when": "view == tooManyCooksAgents && viewItem == deletableAgent",
+          "group": "2_actions@1"
+        },
+        {
+          "command": "tooManyCooks.deleteAgent",
+          "when": "view == tooManyCooksAgents && viewItem == deletableAgent",
+          "group": "9_danger@1"
+        },
+        {
+          "command": "tooManyCooks.copyMessageContent",
+          "when": "view == tooManyCooksMessages && viewItem == message",
+          "group": "1_copy@1"
+        },
+        {
+          "command": "tooManyCooks.copyMessageAsQuote",
+          "when": "view == tooManyCooksMessages && viewItem == message",
+          "group": "1_copy@2"
+        },
+        {
+          "command": "tooManyCooks.copyMessages",
+          "when": "view == tooManyCooksMessages && viewItem == message",
+          "group": "1_copy@3"
+        },
+        {
+          "command": "tooManyCooks.copyMessageSender",
+          "when": "view == tooManyCooksMessages && viewItem == message",
+          "group": "2_metadata@1"
+        },
+        {
+          "command": "tooManyCooks.copyMessageRecipient",
+          "when": "view == tooManyCooksMessages && viewItem == message",
+          "group": "2_metadata@2"
+        },
+        {
+          "command": "tooManyCooks.copyMessageId",
+          "when": "view == tooManyCooksMessages && viewItem == message",
+          "group": "2_metadata@3"
         }
       ]
     },

--- a/too_many_cooks_vscode_extension/src/extension.ts
+++ b/too_many_cooks_vscode_extension/src/extension.ts
@@ -26,6 +26,15 @@ import { createMcpConfigManager } from './services/mcpConfigManager';
 import { createTestAPI } from './testApi';
 import { getDialogService } from './services/dialogService';
 import { registerDeleteAgentCommand, registerDeleteAllAgentsCommand } from './ui/deleteAgentCommands';
+import {
+  registerCopyAgentNameCommand,
+  registerCopyMessageAsQuoteCommand,
+  registerCopyMessageContentCommand,
+  registerCopyMessageIdCommand,
+  registerCopyMessageRecipientCommand,
+  registerCopyMessageSenderCommand,
+  registerCopyMessagesCommand,
+} from './ui/messageCommands';
 import { registerSendMessageCommand } from './ui/sendMessageCommand';
 
 // eslint-disable-next-line @typescript-eslint/no-inferrable-types
@@ -106,21 +115,33 @@ export function deactivate(): void {
 
 interface Providers {
   readonly agentsProvider: AgentsTreeProvider;
+  readonly agentsTreeView: vscode.TreeView<unknown>;
   readonly locksProvider: LocksTreeProvider;
   readonly messagesProvider: MessagesTreeProvider;
+  readonly messagesTreeView: vscode.TreeView<unknown>;
 }
 
 function createProviders(storeManager: StoreManager): Providers {
   const agentsProvider: AgentsTreeProvider = new AgentsTreeProvider(storeManager);
   const locksProvider: LocksTreeProvider = new LocksTreeProvider(storeManager);
   const messagesProvider: MessagesTreeProvider = new MessagesTreeProvider(storeManager);
-  vscode.window.createTreeView('tooManyCooksAgents', {
-    showCollapseAll: true,
-    treeDataProvider: agentsProvider,
-  });
+  const agentsTreeView: vscode.TreeView<unknown> = vscode.window.createTreeView(
+    'tooManyCooksAgents',
+    {
+      canSelectMany: true,
+      showCollapseAll: true,
+      treeDataProvider: agentsProvider,
+    },
+  );
   vscode.window.createTreeView('tooManyCooksLocks', { treeDataProvider: locksProvider });
-  vscode.window.createTreeView('tooManyCooksMessages', { treeDataProvider: messagesProvider });
-  return { agentsProvider, locksProvider, messagesProvider };
+  const messagesTreeView: vscode.TreeView<unknown> = vscode.window.createTreeView(
+    'tooManyCooksMessages',
+    {
+      canSelectMany: true,
+      treeDataProvider: messagesProvider,
+    },
+  );
+  return { agentsProvider, agentsTreeView, locksProvider, messagesProvider, messagesTreeView };
 }
 
 async function autoConnectOnActivation(
@@ -158,6 +179,13 @@ function registerAllCommands(
   context.subscriptions.push(registerDeleteAgentCommand(sm, log));
   context.subscriptions.push(registerDeleteAllAgentsCommand(sm, log));
   context.subscriptions.push(registerSendMessageCommand(sm, log));
+  context.subscriptions.push(registerCopyMessageContentCommand());
+  context.subscriptions.push(registerCopyMessageAsQuoteCommand());
+  context.subscriptions.push(registerCopyMessageIdCommand());
+  context.subscriptions.push(registerCopyMessageSenderCommand());
+  context.subscriptions.push(registerCopyMessageRecipientCommand());
+  context.subscriptions.push(registerCopyMessagesCommand());
+  context.subscriptions.push(registerCopyAgentNameCommand());
 }
 
 function registerChooseConnectionCommand(deps: ConnectionPickerDeps): vscode.Disposable {

--- a/too_many_cooks_vscode_extension/src/ui/deleteAgentCommands.ts
+++ b/too_many_cooks_vscode_extension/src/ui/deleteAgentCommands.ts
@@ -8,6 +8,49 @@ import { getDialogService } from '../services/dialogService';
 
 type LogFn = (msg: string) => void;
 
+function pickItems(
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  item: vscode.TreeItem | undefined,
+  selection: readonly vscode.TreeItem[] | undefined,
+): readonly vscode.TreeItem[] {
+  if (typeof selection !== 'undefined' && selection.length > 0) { return selection; }
+  if (typeof item === 'undefined') { return []; }
+  return [item];
+}
+
+function collectAgentNames(
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  item: vscode.TreeItem | undefined,
+  selection: readonly vscode.TreeItem[] | undefined,
+): readonly string[] {
+  const source: readonly vscode.TreeItem[] = pickItems(item, selection);
+  const names: string[] = [];
+  for (const candidate of source) {
+    const name: string | null = getAgentNameFromItem(candidate);
+    if (name !== null && !names.includes(name)) { names.push(name); }
+  }
+  return names;
+}
+
+async function deleteAgents(
+  storeManager: Readonly<StoreManager>,
+  logFn: LogFn,
+  names: readonly string[],
+): Promise<void> {
+  const dialogs: DialogService = getDialogService();
+  for (const name of names) {
+    try {
+      await storeManager.deleteAgent(name);
+      logFn(`Removed agent: ${name}`);
+    } catch (err: unknown) {
+      logFn(`Failed to remove agent ${name}: ${String(err)}`);
+      await dialogs.showErrorMessage(`Failed to remove agent ${name}: ${String(err)}`);
+      return;
+    }
+  }
+  await dialogs.showInformationMessage(`Removed ${String(names.length)} agent(s)`);
+}
+
 export function registerDeleteAgentCommand(
   storeManager: Readonly<StoreManager>,
   logFn: LogFn,
@@ -15,27 +58,23 @@ export function registerDeleteAgentCommand(
   return vscode.commands.registerCommand(
     'tooManyCooks.deleteAgent',
     // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-    async (item?: vscode.TreeItem): Promise<void> => {
+    async (item?: vscode.TreeItem, selection?: readonly vscode.TreeItem[]): Promise<void> => {
       const dialogs: DialogService = getDialogService();
-      const agentName: string | null = getAgentNameFromItem(item);
-      if (agentName === null) {
+      const names: readonly string[] = collectAgentNames(item, selection);
+      if (names.length === 0) {
         await dialogs.showErrorMessage('No agent selected');
         return;
       }
+      const promptMsg: string = names.length === 1
+        ? `Remove agent "${names[0] ?? ''}"? This will release all their locks.`
+        : `Remove ${String(names.length)} agents? This will release all their locks.`;
       const confirm: string | undefined = await dialogs.showWarningMessage(
-        `Remove agent "${agentName}"? This will release all their locks.`,
+        promptMsg,
         { modal: true },
         'Remove',
       );
       if (confirm !== 'Remove') { return; }
-      try {
-        await storeManager.deleteAgent(agentName);
-        logFn(`Removed agent: ${agentName}`);
-        await dialogs.showInformationMessage(`Agent removed: ${agentName}`);
-      } catch (err: unknown) {
-        logFn(`Failed to remove agent: ${String(err)}`);
-        await dialogs.showErrorMessage(`Failed to remove agent: ${String(err)}`);
-      }
+      await deleteAgents(storeManager, logFn, names);
     },
   );
 }

--- a/too_many_cooks_vscode_extension/src/ui/messageCommands.ts
+++ b/too_many_cooks_vscode_extension/src/ui/messageCommands.ts
@@ -1,0 +1,209 @@
+// Context-menu copy commands for the Messages and Agents tree views.
+// Each command accepts the clicked item plus the full selection so that
+// Multi-select context-menu invocations copy the whole selection.
+
+import * as vscode from 'vscode';
+import type { DialogService } from '../services/dialogService';
+import type { Message } from '../state/types';
+import { getDialogService } from '../services/dialogService';
+
+const BROADCAST_TARGET: string = '*';
+const BROADCAST_LABEL: string = 'all';
+
+function hasMessage(value: object): value is { readonly message: unknown } {
+  return 'message' in value;
+}
+
+function hasStringProp<K extends string>(
+  value: Readonly<Record<string, unknown>>,
+  key: K,
+): boolean {
+  return typeof value[key] === 'string';
+}
+
+function hasNumberProp<K extends string>(
+  value: Readonly<Record<string, unknown>>,
+  key: K,
+): boolean {
+  return typeof value[key] === 'number';
+}
+
+function isMessage(value: unknown): value is Message {
+  if (typeof value !== 'object' || value === null) { return false; }
+  const record: Readonly<Record<string, unknown>> = { ...value };
+  return (
+    hasStringProp(record, 'id') &&
+    hasStringProp(record, 'fromAgent') &&
+    hasStringProp(record, 'toAgent') &&
+    hasStringProp(record, 'content') &&
+    hasNumberProp(record, 'createdAt')
+  );
+}
+
+function extractMessage(item: unknown): Message | null {
+  if (typeof item !== 'object' || item === null) { return null; }
+  if (!hasMessage(item)) { return null; }
+  const candidate: unknown = item.message;
+  if (!isMessage(candidate)) { return null; }
+  return candidate;
+}
+
+function hasAgentName(value: object): value is { readonly agentName: unknown } {
+  return 'agentName' in value;
+}
+
+function extractAgentName(item: unknown): string | null {
+  if (typeof item !== 'object' || item === null) { return null; }
+  if (!hasAgentName(item)) { return null; }
+  const candidate: unknown = item.agentName;
+  if (typeof candidate !== 'string') { return null; }
+  return candidate;
+}
+
+function collectMessages(
+  item: unknown,
+  selection: readonly unknown[] | undefined,
+): readonly Message[] {
+  const items: readonly unknown[] = pickItems(item, selection);
+  const out: Message[] = [];
+  for (const candidate of items) {
+    const msg: Message | null = extractMessage(candidate);
+    if (msg !== null) { out.push(msg); }
+  }
+  return out;
+}
+
+function collectAgentNames(
+  item: unknown,
+  selection: readonly unknown[] | undefined,
+): readonly string[] {
+  const items: readonly unknown[] = pickItems(item, selection);
+  const out: string[] = [];
+  for (const candidate of items) {
+    const name: string | null = extractAgentName(candidate);
+    if (name !== null && !out.includes(name)) { out.push(name); }
+  }
+  return out;
+}
+
+function pickItems(
+  item: unknown,
+  selection: readonly unknown[] | undefined,
+): readonly unknown[] {
+  if (typeof selection !== 'undefined' && selection.length > 0) { return selection; }
+  if (typeof item === 'undefined') { return []; }
+  return [item];
+}
+
+function formatTarget(toAgent: string): string {
+  return toAgent === BROADCAST_TARGET ? BROADCAST_LABEL : toAgent;
+}
+
+function formatMessageQuote(msg: Readonly<Message>): string {
+  return `${msg.fromAgent} → ${formatTarget(msg.toAgent)}: ${msg.content}`;
+}
+
+async function copyToClipboard(value: string, successMessage: string): Promise<void> {
+  const dialogs: DialogService = getDialogService();
+  if (value.length === 0) {
+    await dialogs.showErrorMessage('Nothing to copy');
+    return;
+  }
+  await vscode.env.clipboard.writeText(value);
+  await dialogs.showInformationMessage(successMessage);
+}
+
+export function registerCopyMessageContentCommand(): vscode.Disposable {
+  return vscode.commands.registerCommand(
+    'tooManyCooks.copyMessageContent',
+    async (item?: unknown, selection?: readonly unknown[]): Promise<void> => {
+      const messages: readonly Message[] = collectMessages(item, selection);
+      const text: string = messages
+        .map((msg: Readonly<Message>): string => { return msg.content; })
+        .join('\n\n');
+      await copyToClipboard(text, `Copied ${String(messages.length)} message(s) content`);
+    },
+  );
+}
+
+export function registerCopyMessageAsQuoteCommand(): vscode.Disposable {
+  return vscode.commands.registerCommand(
+    'tooManyCooks.copyMessageAsQuote',
+    async (item?: unknown, selection?: readonly unknown[]): Promise<void> => {
+      const messages: readonly Message[] = collectMessages(item, selection);
+      const text: string = messages.map(formatMessageQuote).join('\n');
+      await copyToClipboard(text, `Copied ${String(messages.length)} quoted message(s)`);
+    },
+  );
+}
+
+export function registerCopyMessageIdCommand(): vscode.Disposable {
+  return vscode.commands.registerCommand(
+    'tooManyCooks.copyMessageId',
+    async (item?: unknown, selection?: readonly unknown[]): Promise<void> => {
+      const messages: readonly Message[] = collectMessages(item, selection);
+      const text: string = messages
+        .map((msg: Readonly<Message>): string => { return msg.id; })
+        .join('\n');
+      await copyToClipboard(text, `Copied ${String(messages.length)} message ID(s)`);
+    },
+  );
+}
+
+export function registerCopyMessageSenderCommand(): vscode.Disposable {
+  return vscode.commands.registerCommand(
+    'tooManyCooks.copyMessageSender',
+    async (item?: unknown, selection?: readonly unknown[]): Promise<void> => {
+      const messages: readonly Message[] = collectMessages(item, selection);
+      const senders: string[] = [];
+      for (const msg of messages) {
+        if (!senders.includes(msg.fromAgent)) { senders.push(msg.fromAgent); }
+      }
+      await copyToClipboard(senders.join('\n'), `Copied ${String(senders.length)} sender(s)`);
+    },
+  );
+}
+
+export function registerCopyMessageRecipientCommand(): vscode.Disposable {
+  return vscode.commands.registerCommand(
+    'tooManyCooks.copyMessageRecipient',
+    async (item?: unknown, selection?: readonly unknown[]): Promise<void> => {
+      const messages: readonly Message[] = collectMessages(item, selection);
+      const recipients: string[] = [];
+      for (const msg of messages) {
+        const target: string = formatTarget(msg.toAgent);
+        if (!recipients.includes(target)) { recipients.push(target); }
+      }
+      await copyToClipboard(
+        recipients.join('\n'),
+        `Copied ${String(recipients.length)} recipient(s)`,
+      );
+    },
+  );
+}
+
+export function registerCopyMessagesCommand(): vscode.Disposable {
+  return vscode.commands.registerCommand(
+    'tooManyCooks.copyMessages',
+    async (item?: unknown, selection?: readonly unknown[]): Promise<void> => {
+      const messages: readonly Message[] = collectMessages(item, selection);
+      const text: string = messages
+        .map((msg: Readonly<Message>): string => {
+          return `[${String(new Date(msg.createdAt).toISOString())}] ` +
+            `${msg.fromAgent} → ${formatTarget(msg.toAgent)}\n${msg.content}`;
+        })
+        .join('\n\n---\n\n');
+      await copyToClipboard(text, `Copied ${String(messages.length)} message(s)`);
+    },
+  );
+}
+
+export function registerCopyAgentNameCommand(): vscode.Disposable {
+  return vscode.commands.registerCommand(
+    'tooManyCooks.copyAgentName',
+    async (item?: unknown, selection?: readonly unknown[]): Promise<void> => {
+      const names: readonly string[] = collectAgentNames(item, selection);
+      await copyToClipboard(names.join('\n'), `Copied ${String(names.length)} agent name(s)`);
+    },
+  );
+}

--- a/too_many_cooks_vscode_extension/src/ui/sendMessageCommand.ts
+++ b/too_many_cooks_vscode_extension/src/ui/sendMessageCommand.ts
@@ -17,21 +17,50 @@ export function registerSendMessageCommand(
   return vscode.commands.registerCommand(
     'tooManyCooks.sendMessage',
     // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-    async (item?: vscode.TreeItem): Promise<void> => {
-      await handleSendMessage(storeManager, logFn, item);
+    async (item?: vscode.TreeItem, selection?: readonly vscode.TreeItem[]): Promise<void> => {
+      await handleSendMessage(storeManager, logFn, { item, selection });
     },
   );
+}
+
+interface SendInvocation {
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  readonly item: vscode.TreeItem | undefined;
+  readonly selection: readonly vscode.TreeItem[] | undefined;
+}
+
+interface DeliverArgs {
+  readonly content: string;
+  readonly fromAgent: string;
+  readonly recipients: readonly string[];
+  readonly storeManager: Readonly<StoreManager>;
+}
+
+function pickItems(invocation: Readonly<SendInvocation>): readonly vscode.TreeItem[] {
+  const { item, selection }: Readonly<SendInvocation> = invocation;
+  if (typeof selection !== 'undefined' && selection.length > 0) { return selection; }
+  if (typeof item === 'undefined') { return []; }
+  return [item];
+}
+
+function collectRecipients(invocation: Readonly<SendInvocation>): readonly string[] {
+  const source: readonly vscode.TreeItem[] = pickItems(invocation);
+  const names: string[] = [];
+  for (const candidate of source) {
+    const name: string | null = getAgentNameFromItem(candidate);
+    if (name !== null && !names.includes(name)) { names.push(name); }
+  }
+  return names;
 }
 
 async function handleSendMessage(
   storeManager: Readonly<StoreManager>,
   logFn: (message: string) => void,
-  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-  item?: vscode.TreeItem,
+  invocation: Readonly<SendInvocation>,
 ): Promise<void> {
   const dialogs: DialogService = getDialogService();
-  const toAgent: string | null = await selectRecipient(storeManager, item);
-  if (toAgent === null) { return; }
+  const recipients: readonly string[] = await selectRecipients(storeManager, invocation);
+  if (recipients.length === 0) { return; }
 
   const fromAgent: string | undefined = await dialogs.showQuickPick(
     storeManager.state.agents.map(
@@ -41,23 +70,49 @@ async function handleSendMessage(
   );
   if (typeof fromAgent === 'undefined') { return; }
 
+  const targetsLabel: string = recipients.join(', ');
   const content: string | undefined = await dialogs.showInputBox({
     placeHolder: 'Enter your message...',
-    prompt: `Message to ${toAgent}`,
+    prompt: `Message to ${targetsLabel}`,
   });
   if (typeof content === 'undefined') { return; }
 
-  try {
-    await storeManager.sendMessage(fromAgent, toAgent, content);
-    const preview: string = content.length > MESSAGE_PREVIEW_LENGTH
-      ? `${content.substring(0, MESSAGE_PREVIEW_LENGTH)}...`
-      : content;
-    await dialogs.showInformationMessage(`Message sent to ${toAgent}: "${preview}"`);
-    logFn(`Message sent from ${fromAgent} to ${toAgent}: ${content}`);
-  } catch (err: unknown) {
-    logFn(`Failed to send message: ${String(err)}`);
-    await dialogs.showErrorMessage(`Failed to send message: ${String(err)}`);
+  await deliverMessages(logFn, { content, fromAgent, recipients, storeManager });
+}
+
+async function deliverMessages(
+  logFn: (message: string) => void,
+  args: Readonly<DeliverArgs>,
+): Promise<void> {
+  const dialogs: DialogService = getDialogService();
+  const { content, fromAgent, recipients, storeManager }: Readonly<DeliverArgs> = args;
+  const preview: string = content.length > MESSAGE_PREVIEW_LENGTH
+    ? `${content.substring(0, MESSAGE_PREVIEW_LENGTH)}...`
+    : content;
+  for (const toAgent of recipients) {
+    try {
+      await storeManager.sendMessage(fromAgent, toAgent, content);
+      logFn(`Message sent from ${fromAgent} to ${toAgent}: ${content}`);
+    } catch (err: unknown) {
+      logFn(`Failed to send message to ${toAgent}: ${String(err)}`);
+      await dialogs.showErrorMessage(`Failed to send message to ${toAgent}: ${String(err)}`);
+      return;
+    }
   }
+  await dialogs.showInformationMessage(
+    `Message sent to ${String(recipients.length)} recipient(s): "${preview}"`,
+  );
+}
+
+async function selectRecipients(
+  storeManager: Readonly<StoreManager>,
+  invocation: Readonly<SendInvocation>,
+): Promise<readonly string[]> {
+  const fromSelection: readonly string[] = collectRecipients(invocation);
+  if (fromSelection.length > 0) { return fromSelection; }
+
+  const fallback: string | null = await selectRecipient(storeManager, invocation.item);
+  return fallback === null ? [] : [fallback];
 }
 
 async function selectRecipient(

--- a/too_many_cooks_vscode_extension/test/suite/deleteAllAgents.test.ts
+++ b/too_many_cooks_vscode_extension/test/suite/deleteAllAgents.test.ts
@@ -1,19 +1,114 @@
-// Delete All Agents: the view title button removes every registered agent.
+// Delete-agent referential integrity E2E.
+//
+// PROVES (end-to-end, through the live VSIX → MCP server → SQLite path) that
+// deleting an agent cascades through every related table:
+//   - the agent disappears from the Agents tree
+//   - every lock that agent held disappears from the Locks tree
+//   - every plan that agent owned disappears
+//   - every message that agent SENT disappears
+//   - every message that agent RECEIVED disappears
+//   - other agents and their data are completely untouched
+//
+// The schema enforces this via ON DELETE CASCADE on locks, plans, and BOTH
+// messages.from_agent AND messages.to_agent. If any FK is dropped, these
+// assertions catch it immediately — no more orphaned rows in the UI.
 
 import {
   waitForExtensionActivation,
   waitForConnection,
   waitForAgentInTree,
   waitForAgentGone,
+  waitForLockInTree,
+  waitForLockGone,
+  waitForMessageInTree,
+  waitForCondition,
   safeDisconnect,
   getTestAPI,
   callToolString,
+  extractKeyFromResult,
   resetServerState,
   assertOk,
   assertEqual,
+  dumpTree,
 } from './testHelpers';
 
-suite('Delete All Agents', () => {
+interface RegisteredAgent {
+  readonly name: string;
+  readonly key: string;
+}
+
+const register = async (label: string): Promise<RegisteredAgent> => {
+  const api = getTestAPI();
+  const name = `${label}-${String(Date.now())}-${String(Math.floor(Math.random() * 100000))}`;
+  const raw = await callToolString(api, 'register', { name });
+  assertOk(!raw.includes('"error"'), `Register ${name} failed: ${raw}`);
+  const key = extractKeyFromResult(raw);
+  assertOk(key.length > 0, `Register ${name} returned empty key`);
+  return { key, name };
+};
+
+const acquireLock = async (agent: RegisteredAgent, filePath: string): Promise<void> => {
+  const api = getTestAPI();
+  const raw = await callToolString(api, 'lock', {
+    action: 'acquire',
+    agent_key: agent.key,
+    agent_name: agent.name,
+    file_path: filePath,
+    reason: `edit-${filePath}`,
+  });
+  assertOk(!raw.includes('"error"'), `Acquire ${filePath} by ${agent.name} failed: ${raw}`);
+};
+
+const sendMessage = async (
+  from: RegisteredAgent,
+  toAgentName: string,
+  content: string,
+): Promise<void> => {
+  const api = getTestAPI();
+  const raw = await callToolString(api, 'message', {
+    action: 'send',
+    agent_key: from.key,
+    agent_name: from.name,
+    content,
+    to_agent: toAgentName,
+  });
+  assertOk(!raw.includes('"error"'), `Send "${content}" from ${from.name} to ${toAgentName} failed: ${raw}`);
+};
+
+const updatePlan = async (
+  agent: RegisteredAgent,
+  goal: string,
+  currentTask: string,
+): Promise<void> => {
+  const api = getTestAPI();
+  const raw = await callToolString(api, 'plan', {
+    action: 'update',
+    agent_key: agent.key,
+    agent_name: agent.name,
+    current_task: currentTask,
+    goal,
+  });
+  assertOk(!raw.includes('"error"'), `Plan for ${agent.name} failed: ${raw}`);
+};
+
+const countMessagesInvolving = (agentName: string): number => {
+  const api = getTestAPI();
+  return api.getMessages().filter(
+    (m) => m.fromAgent === agentName || m.toAgent === agentName,
+  ).length;
+};
+
+const countLocksHeldBy = (agentName: string): number => {
+  const api = getTestAPI();
+  return api.getLocks().filter((l) => l.agentName === agentName).length;
+};
+
+const planExistsFor = (agentName: string): boolean => {
+  const api = getTestAPI();
+  return api.getPlans().some((p) => p.agentName === agentName);
+};
+
+suite('Delete Agent — Referential Integrity (cascade proof)', () => {
   suiteSetup(async () => {
     await waitForExtensionActivation();
     const api = getTestAPI();
@@ -22,42 +117,270 @@ suite('Delete All Agents', () => {
       await waitForConnection();
     }
     await resetServerState();
+    await api.refreshStatus();
   });
 
   suiteTeardown(async () => {
     await safeDisconnect();
   });
 
-  test('deleteAllAgents removes all registered agents', async () => {
+  test('deleting a single agent cascades to its locks, plans, outbound, inbound, and broadcast messages — and leaves everyone else intact', async () => {
     const api = getTestAPI();
+    await resetServerState();
+    await api.refreshStatus();
+    await waitForCondition(() => api.getAgentCount() === 0, 'agents to drain after reset');
 
-    // 1. Register multiple agents
-    const agentA = `all-delete-a-${Date.now()}`;
-    const agentB = `all-delete-b-${Date.now()}`;
-    const agentC = `all-delete-c-${Date.now()}`;
+    // Build a small graph: alice (doomed) interacts with bob, carol, dave.
+    const alice = await register('cascade-alice');
+    const bob = await register('cascade-bob');
+    const carol = await register('cascade-carol');
+    const dave = await register('cascade-dave');
 
-    const resultA = await callToolString(api, 'register', { name: agentA });
-    assertOk(!resultA.includes('"error"'), `Register A failed: ${resultA}`);
+    await waitForAgentInTree(api, alice.name);
+    await waitForAgentInTree(api, bob.name);
+    await waitForAgentInTree(api, carol.name);
+    await waitForAgentInTree(api, dave.name);
 
-    const resultB = await callToolString(api, 'register', { name: agentB });
-    assertOk(!resultB.includes('"error"'), `Register B failed: ${resultB}`);
+    // Alice grabs two locks; dave grabs one (must survive alice's delete).
+    await acquireLock(alice, '/src/alice/one.ts');
+    await acquireLock(alice, '/src/alice/two.ts');
+    await acquireLock(dave, '/src/dave/keepme.ts');
 
-    const resultC = await callToolString(api, 'register', { name: agentC });
-    assertOk(!resultC.includes('"error"'), `Register C failed: ${resultC}`);
+    // Plans: alice + bob set plans (alice's must vanish, bob's must survive).
+    await updatePlan(alice, 'Alice goal — will vanish', 'doomed task');
+    await updatePlan(bob, 'Bob goal — must survive', 'safe task');
 
-    // 2. Verify all 3 agents appear in tree
-    await waitForAgentInTree(api, agentA);
-    await waitForAgentInTree(api, agentB);
-    await waitForAgentInTree(api, agentC);
-    assertOk(api.getAgentCount() >= 3, 'Should have at least 3 agents');
+    // Messages: outbound from alice, inbound to alice, broadcast from alice,
+    // plus an unrelated bob ↔ dave conversation that must not be touched.
+    await sendMessage(alice, bob.name, 'cascade-alice-to-bob');
+    await sendMessage(alice, carol.name, 'cascade-alice-to-carol');
+    await sendMessage(bob, alice.name, 'cascade-bob-to-alice');
+    await sendMessage(carol, alice.name, 'cascade-carol-to-alice');
+    await sendMessage(alice, '*', 'cascade-alice-broadcast');
+    await sendMessage(bob, dave.name, 'cascade-bob-to-dave-unrelated');
+    await sendMessage(dave, bob.name, 'cascade-dave-to-bob-unrelated');
 
-    // 3. Delete all agents
+    // Wait for all tree views to catch up so we have a real "before" snapshot.
+    await waitForLockInTree(api, '/src/alice/one.ts');
+    await waitForLockInTree(api, '/src/alice/two.ts');
+    await waitForLockInTree(api, '/src/dave/keepme.ts');
+    await waitForMessageInTree(api, 'cascade-alice-to-bob');
+    await waitForMessageInTree(api, 'cascade-alice-to-carol');
+    await waitForMessageInTree(api, 'cascade-bob-to-alice');
+    await waitForMessageInTree(api, 'cascade-carol-to-alice');
+    await waitForMessageInTree(api, 'cascade-alice-broadcast');
+    await waitForMessageInTree(api, 'cascade-bob-to-dave-unrelated');
+    await waitForMessageInTree(api, 'cascade-dave-to-bob-unrelated');
+    await waitForCondition(() => api.getMessageCount() === 7, 'all 7 messages to land in the store');
+    await waitForCondition(() => api.getPlans().length === 2, 'both plans to land in the store');
+
+    // === BEFORE snapshot — sanity assertions ===
+    dumpTree('AGENTS-before', api.getAgentsTreeSnapshot());
+    dumpTree('LOCKS-before', api.getLocksTreeSnapshot());
+    dumpTree('MESSAGES-before', api.getMessagesTreeSnapshot());
+
+    assertEqual(api.getAgentCount(), 4, 'before: 4 agents registered');
+    assertOk(api.findAgentInTree(alice.name) !== null, 'before: alice in agents tree');
+    assertOk(api.findAgentInTree(bob.name) !== null, 'before: bob in agents tree');
+    assertOk(api.findAgentInTree(carol.name) !== null, 'before: carol in agents tree');
+    assertOk(api.findAgentInTree(dave.name) !== null, 'before: dave in agents tree');
+    assertEqual(countLocksHeldBy(alice.name), 2, 'before: alice holds 2 locks');
+    assertEqual(countLocksHeldBy(dave.name), 1, 'before: dave holds 1 lock');
+    assertEqual(api.getLockCount(), 3, 'before: 3 total locks');
+    assertOk(planExistsFor(alice.name), 'before: alice has a plan');
+    assertOk(planExistsFor(bob.name), 'before: bob has a plan');
+    assertEqual(api.getPlans().length, 2, 'before: 2 plans total');
+    assertEqual(countMessagesInvolving(alice.name), 5, 'before: alice in 5 messages (2 out + 2 in + 1 broadcast)');
+    assertEqual(api.getMessageCount(), 7, 'before: 7 total messages');
+    assertOk(api.findMessageInTree('cascade-alice-broadcast') !== null, 'before: broadcast visible');
+    assertOk(api.findMessageInTree('cascade-bob-to-dave-unrelated') !== null, 'before: unrelated bob→dave visible');
+
+    // === ACT — delete alice through the VSIX admin path ===
+    await api.deleteAgent(alice.name);
+    await waitForAgentGone(api, alice.name);
+    await waitForLockGone(api, '/src/alice/one.ts');
+    await waitForLockGone(api, '/src/alice/two.ts');
+    await waitForCondition(
+      () => countMessagesInvolving(alice.name) === 0,
+      'all messages involving alice to disappear',
+    );
+
+    // === AFTER snapshot — DOUBLE-DOWN assertions ===
+    dumpTree('AGENTS-after-alice-delete', api.getAgentsTreeSnapshot());
+    dumpTree('LOCKS-after-alice-delete', api.getLocksTreeSnapshot());
+    dumpTree('MESSAGES-after-alice-delete', api.getMessagesTreeSnapshot());
+
+    // Agent gone
+    assertEqual(api.findAgentInTree(alice.name), null, 'after: alice not in agents tree');
+    assertEqual(api.getAgentCount(), 3, 'after: 3 agents remain');
+    // Survivors still present
+    assertOk(api.findAgentInTree(bob.name) !== null, 'after: bob survives');
+    assertOk(api.findAgentInTree(carol.name) !== null, 'after: carol survives');
+    assertOk(api.findAgentInTree(dave.name) !== null, 'after: dave survives');
+    // Locks
+    assertEqual(countLocksHeldBy(alice.name), 0, 'after: zero locks held by alice');
+    assertEqual(api.findLockInTree('/src/alice/one.ts'), null, 'after: /src/alice/one.ts NOT in locks tree');
+    assertEqual(api.findLockInTree('/src/alice/two.ts'), null, 'after: /src/alice/two.ts NOT in locks tree');
+    assertOk(api.findLockInTree('/src/dave/keepme.ts') !== null, 'after: dave\'s lock survives');
+    assertEqual(api.getLockCount(), 1, 'after: 1 lock total (dave\'s)');
+    // Plans
+    assertOk(!planExistsFor(alice.name), 'after: alice has no plan');
+    assertOk(planExistsFor(bob.name), 'after: bob\'s plan survives');
+    assertEqual(api.getPlans().length, 1, 'after: 1 plan total (bob\'s)');
+    // Messages — both directions cleaned, broadcast cleaned, unrelated untouched
+    assertEqual(countMessagesInvolving(alice.name), 0, 'after: ZERO messages touch alice (no orphans!)');
+    assertEqual(api.findMessageInTree('cascade-alice-to-bob'), null, 'after: outbound alice→bob gone');
+    assertEqual(api.findMessageInTree('cascade-alice-to-carol'), null, 'after: outbound alice→carol gone');
+    assertEqual(api.findMessageInTree('cascade-bob-to-alice'), null, 'after: inbound bob→alice gone');
+    assertEqual(api.findMessageInTree('cascade-carol-to-alice'), null, 'after: inbound carol→alice gone');
+    assertEqual(api.findMessageInTree('cascade-alice-broadcast'), null, 'after: alice broadcast gone');
+    assertOk(api.findMessageInTree('cascade-bob-to-dave-unrelated') !== null, 'after: unrelated bob→dave survives');
+    assertOk(api.findMessageInTree('cascade-dave-to-bob-unrelated') !== null, 'after: unrelated dave→bob survives');
+    assertEqual(api.getMessageCount(), 2, 'after: exactly 2 unrelated messages remain');
+  });
+
+  test('deleting the recipient of a message removes that message (the exact bug from the user\'s screenshot)', async () => {
+    const api = getTestAPI();
+    await resetServerState();
+    await api.refreshStatus();
+    await waitForCondition(() => api.getAgentCount() === 0, 'agents to drain after reset');
+
+    const sender = await register('orphan-sender');
+    const doomed = await register('orphan-doomed-recipient');
+    const witness = await register('orphan-witness');
+
+    await waitForAgentInTree(api, sender.name);
+    await waitForAgentInTree(api, doomed.name);
+    await waitForAgentInTree(api, witness.name);
+
+    await sendMessage(sender, doomed.name, 'orphan-msg-1');
+    await sendMessage(sender, doomed.name, 'orphan-msg-2');
+    await sendMessage(sender, doomed.name, 'orphan-msg-3');
+    await sendMessage(sender, witness.name, 'orphan-witness-keepme');
+
+    await waitForMessageInTree(api, 'orphan-msg-1');
+    await waitForMessageInTree(api, 'orphan-msg-2');
+    await waitForMessageInTree(api, 'orphan-msg-3');
+    await waitForMessageInTree(api, 'orphan-witness-keepme');
+    await waitForCondition(() => api.getMessageCount() === 4, 'all 4 messages to land in the store');
+
+    // BEFORE
+    assertEqual(api.getMessageCount(), 4, 'before: 4 messages total');
+    assertEqual(countMessagesInvolving(doomed.name), 3, 'before: 3 messages target the doomed agent');
+    assertOk(api.findAgentInTree(doomed.name) !== null, 'before: doomed agent present');
+    assertOk(api.findMessageInTree('orphan-msg-1') !== null, 'before: orphan-msg-1 visible in tree');
+    assertOk(api.findMessageInTree('orphan-msg-2') !== null, 'before: orphan-msg-2 visible in tree');
+    assertOk(api.findMessageInTree('orphan-msg-3') !== null, 'before: orphan-msg-3 visible in tree');
+
+    // ACT: delete the RECEIVER. Pre-fix this left messages orphaned with no
+    // matching identity row — exactly what produced the user's screenshot.
+    await api.deleteAgent(doomed.name);
+    await waitForAgentGone(api, doomed.name);
+    await waitForCondition(
+      () => countMessagesInvolving(doomed.name) === 0,
+      'inbound messages to vanish with the recipient',
+    );
+
+    // AFTER
+    assertEqual(api.findAgentInTree(doomed.name), null, 'after: doomed agent gone from tree');
+    assertEqual(countMessagesInvolving(doomed.name), 0, 'after: no orphaned messages reference the dead recipient');
+    assertEqual(api.findMessageInTree('orphan-msg-1'), null, 'after: orphan-msg-1 cascade-deleted');
+    assertEqual(api.findMessageInTree('orphan-msg-2'), null, 'after: orphan-msg-2 cascade-deleted');
+    assertEqual(api.findMessageInTree('orphan-msg-3'), null, 'after: orphan-msg-3 cascade-deleted');
+    assertOk(api.findMessageInTree('orphan-witness-keepme') !== null, 'after: unrelated witness message survives');
+    assertEqual(api.getMessageCount(), 1, 'after: exactly 1 message remains');
+    assertEqual(api.getAgentCount(), 2, 'after: 2 agents survive');
+  });
+
+  test('deleteAllAgents wipes every agent, every lock, every plan, and every message in one shot', async () => {
+    const api = getTestAPI();
+    await resetServerState();
+    await api.refreshStatus();
+    await waitForCondition(() => api.getAgentCount() === 0, 'agents to drain after reset');
+
+    // Stand up a small population with locks, plans, direct + broadcast msgs.
+    const a = await register('all-delete-a');
+    const b = await register('all-delete-b');
+    const c = await register('all-delete-c');
+
+    await waitForAgentInTree(api, a.name);
+    await waitForAgentInTree(api, b.name);
+    await waitForAgentInTree(api, c.name);
+
+    await acquireLock(a, '/all/a1.ts');
+    await acquireLock(a, '/all/a2.ts');
+    await acquireLock(b, '/all/b1.ts');
+    await acquireLock(c, '/all/c1.ts');
+
+    await updatePlan(a, 'plan-a-goal', 'plan-a-task');
+    await updatePlan(b, 'plan-b-goal', 'plan-b-task');
+    await updatePlan(c, 'plan-c-goal', 'plan-c-task');
+
+    await sendMessage(a, b.name, 'all-msg-a-to-b');
+    await sendMessage(b, c.name, 'all-msg-b-to-c');
+    await sendMessage(c, a.name, 'all-msg-c-to-a');
+    await sendMessage(a, '*', 'all-broadcast-from-a');
+
+    await waitForLockInTree(api, '/all/a1.ts');
+    await waitForLockInTree(api, '/all/a2.ts');
+    await waitForLockInTree(api, '/all/b1.ts');
+    await waitForLockInTree(api, '/all/c1.ts');
+    await waitForMessageInTree(api, 'all-msg-a-to-b');
+    await waitForMessageInTree(api, 'all-msg-b-to-c');
+    await waitForMessageInTree(api, 'all-msg-c-to-a');
+    await waitForMessageInTree(api, 'all-broadcast-from-a');
+    await waitForCondition(() => api.getMessageCount() === 4, 'all 4 messages to land in the store');
+    await waitForCondition(() => api.getLockCount() === 4, 'all 4 locks to land in the store');
+    await waitForCondition(() => api.getPlans().length === 3, 'all 3 plans to land in the store');
+
+    // BEFORE
+    assertEqual(api.getAgentCount(), 3, 'before: 3 agents');
+    assertEqual(api.getLockCount(), 4, 'before: 4 locks');
+    assertEqual(api.getPlans().length, 3, 'before: 3 plans');
+    assertEqual(api.getMessageCount(), 4, 'before: 4 messages');
+
+    // ACT: delete-all through the VSIX command path.
     await api.deleteAllAgents();
+    await waitForAgentGone(api, a.name);
+    await waitForAgentGone(api, b.name);
+    await waitForAgentGone(api, c.name);
+    await waitForLockGone(api, '/all/a1.ts');
+    await waitForLockGone(api, '/all/b1.ts');
+    await waitForCondition(() => api.getMessageCount() === 0, 'all messages to drain');
 
-    // 4. Verify all agents are gone
-    await waitForAgentGone(api, agentA);
-    await waitForAgentGone(api, agentB);
-    await waitForAgentGone(api, agentC);
-    assertEqual(api.getAgentCount(), 0, 'All agents should be removed');
+    // AFTER — every assertion that can possibly fire, fires.
+    dumpTree('AGENTS-after-all', api.getAgentsTreeSnapshot());
+    dumpTree('LOCKS-after-all', api.getLocksTreeSnapshot());
+    dumpTree('MESSAGES-after-all', api.getMessagesTreeSnapshot());
+
+    assertEqual(api.getAgentCount(), 0, 'after: zero agents');
+    assertEqual(api.findAgentInTree(a.name), null, 'after: a gone from tree');
+    assertEqual(api.findAgentInTree(b.name), null, 'after: b gone from tree');
+    assertEqual(api.findAgentInTree(c.name), null, 'after: c gone from tree');
+    assertEqual(api.getLockCount(), 0, 'after: zero locks');
+    assertEqual(api.findLockInTree('/all/a1.ts'), null);
+    assertEqual(api.findLockInTree('/all/a2.ts'), null);
+    assertEqual(api.findLockInTree('/all/b1.ts'), null);
+    assertEqual(api.findLockInTree('/all/c1.ts'), null);
+    assertEqual(api.getPlans().length, 0, 'after: zero plans');
+    assertEqual(api.getMessageCount(), 0, 'after: zero messages');
+    assertEqual(api.findMessageInTree('all-msg-a-to-b'), null);
+    assertEqual(api.findMessageInTree('all-msg-b-to-c'), null);
+    assertEqual(api.findMessageInTree('all-msg-c-to-a'), null);
+    assertEqual(api.findMessageInTree('all-broadcast-from-a'), null);
+
+    // The broadcast sentinel '*' must NOT be visible as a deletable agent in
+    // the UI, and the tree count must reflect that.
+    assertEqual(api.findAgentInTree('*'), null, 'after: broadcast sentinel never appears as an agent');
+
+    // Re-registering after a full wipe must still work — and broadcasts must
+    // still work, which proves the '*' sentinel survived the delete-all.
+    const fresh = await register('after-wipe');
+    await waitForAgentInTree(api, fresh.name);
+    await sendMessage(fresh, '*', 'after-wipe-broadcast');
+    await waitForMessageInTree(api, 'after-wipe-broadcast');
+    assertEqual(api.getAgentCount(), 1, 'post-wipe: 1 fresh agent');
+    assertEqual(api.getMessageCount(), 1, 'post-wipe: 1 broadcast message');
+    assertOk(api.findMessageInTree('after-wipe-broadcast') !== null, 'post-wipe: broadcast lands');
   });
 });


### PR DESCRIPTION
## TLDR;

Fixes a referential-integrity bug where deleting an agent left orphaned messages behind (visible in the VSIX as messages with no matching agent), and ships multi-select copy/send/delete context-menu commands on the Agents and Messages tree views.

## Details

### Cascade-delete fix (the user-reported bug)

- **Schema:** [`schema.prisma`](too-many-cooks/packages/too-many-cooks/prisma/schema.prisma) — `messages.to_agent` previously had no FK. Added named `MessageFrom`/`MessageTo` relations both with `ON DELETE CASCADE`. Now the DB itself guarantees no orphaned messages.
- **Migration:** new [`20260525000000_add_to_agent_fk_cascade/migration.sql`](too-many-cooks/packages/too-many-cooks/prisma/migrations/20260525000000_add_to_agent_fk_cascade/migration.sql).
- **Broadcast sentinel:** [`db-sqlite.ts`](too-many-cooks/packages/too-many-cooks/src/db-sqlite.ts) seeds a reserved `identity` row with `agent_name='*'`, `active=0` on every DB open so `to_agent='*'` satisfies the new FK without surfacing in the agents list. `register` rejects `'*'`; `adminDeleteAgent` refuses to delete it.
- **Trust the cascade:** `adminDeleteAgent` no longer manually fans out child deletes — a single `DELETE FROM identity` now relies on the FK cascade so any future regression actually fails a test.
- **adminSendMessage parity:** auto-creates both sender AND recipient (as inactive rows) so the new to_agent FK doesn't break admin-initiated sends.

### Tree-view UX: multi-select context menus

- New [`messageCommands.ts`](too_many_cooks_vscode_extension/src/ui/messageCommands.ts): `copyMessageContent`, `copyMessageAsQuote`, `copyMessageId`, `copyMessageSender`, `copyMessageRecipient`, `copyMessages` (bulk), `copyAgentName`. Each accepts the clicked item plus the full selection.
- [`sendMessageCommand.ts`](too_many_cooks_vscode_extension/src/ui/sendMessageCommand.ts) and [`deleteAgentCommands.ts`](too_many_cooks_vscode_extension/src/ui/deleteAgentCommands.ts) now accept a selection array and operate on every selected agent.
- [`extension.ts`](too_many_cooks_vscode_extension/src/extension.ts) sets `canSelectMany: true` on the Agents and Messages tree views and wires the new commands.
- [`package.json`](too_many_cooks_vscode_extension/package.json) registers the commands and groups them in the context menu (`1_copy` / `2_metadata` / `2_actions` / `9_danger`).

## How do the tests prove the changes work?

### Cascade integrity (node-level)

[`foreign_key_integrity_test.ts`](too-many-cooks/packages/too-many-cooks/test/foreign_key_integrity_test.ts) grew from **3 → 10 tests**, all passing:

- `cascade deletes outbound messages (from_agent) when sender is deleted`
- `cascade deletes inbound messages (to_agent) when recipient is deleted — the bug the user reported`
- `rejects message insertion for nonexistent to_agent when FKs enforced`
- `broadcast sentinel row exists so to_agent='*' is FK-valid`
- `register rejects '*' because it would collide with the broadcast sentinel`
- `adminDeleteAgent refuses to delete the broadcast sentinel`
- `cascade is end-to-end: adminDeleteAgent wipes locks, plans, outbound AND inbound messages`
- (plus the original lock/plan cascade + ghost-agent FK-rejection tests)

### Cascade integrity (VSIX → MCP → SQLite E2E)

[`deleteAllAgents.test.ts`](too_many_cooks_vscode_extension/test/suite/deleteAllAgents.test.ts) rewritten as **3 dense E2E tests** driven through the live extension:

1. `deleting a single agent cascades to its locks, plans, outbound, inbound, and broadcast messages — and leaves everyone else intact` — registers 4 agents, sets up 3 locks + 2 plans + 7 messages (mixed direct/broadcast/unrelated), deletes one agent via the VSIX admin path, then asserts both that every related row is gone AND that survivors are untouched (45+ assertions).
2. `deleting the recipient of a message removes that message (the exact bug from the user's screenshot)` — proves orphaned-recipient messages cascade out.
3. `deleteAllAgents wipes every agent, every lock, every plan, and every message in one shot` — also re-registers after the wipe and broadcasts again to prove the `'*'` sentinel survived.

### Full CI simulation

Locally ran the exact CI workflow steps (`.github/workflows/ci.yml`):

- `make lint` — clean (after fixing 4 ESLint errors in the new test file)
- `make build` — clean (MCP server + VSIX + Eleventy site)
- `make test` — all **361 MCP server tests** pass; all **80+ VSIX integration tests** pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)