### PR TITLE
Fix 3 critical bugs: message privacy (#11), Windows server start (#17), status bar label (#12)

### DIFF
--- a/too-many-cooks/packages/core/src/server.ts
+++ b/too-many-cooks/packages/core/src/server.ts
@@ -148,8 +148,11 @@ const planZodSchema: z.ZodRawShape = {
     .describe("Agent key for authentication (optional, uses session if omitted)"),
 };
 
-/** Zod schema for status tool input (empty). */
-const statusZodSchema: z.ZodRawShape = {};
+/** Zod schema for status tool input. */
+const statusZodSchema: z.ZodRawShape = {
+  agent_key: z.string().optional()
+    .describe("Agent key for authentication (optional, uses session if omitted)"),
+};
 
 /**
  * Wrap a local ToolCallback so it satisfies the MCP SDK's typed callback
@@ -203,7 +206,7 @@ const registerTools: (
   server.registerTool(
     "status",
     { description: statusToolConfig.description, inputSchema: statusZodSchema },
-    wrapHandler(createStatusHandler(db, log)),
+    wrapHandler(createStatusHandler(db, log, getSession)),
   );
 };
 

--- a/too-many-cooks/packages/core/src/tools/status_tool.ts
+++ b/too-many-cooks/packages/core/src/tools/status_tool.ts
@@ -12,18 +12,25 @@ import {
 } from "../types.js";
 import {
   type CallToolResult,
+  type SessionGetter,
   type ToolCallback,
   textContent,
 } from "../mcp-types.js";
-import { makeErrorResult } from "./tool_utils.js";
+import { BROADCAST_RECIPIENT } from "../notifications.js";
+import { type IdentityResult, makeErrorResult, resolveIdentity } from "./tool_utils.js";
 
-/** Input schema for status tool (no inputs required). */
+/** Input schema for status tool. */
 export const STATUS_INPUT_SCHEMA: {
   readonly type: "object";
-  readonly properties: Record<string, never>;
+  readonly properties: Record<string, unknown>;
 } = {
   type: "object",
-  properties: {},
+  properties: {
+    agent_key: {
+      type: "string",
+      description: "Agent key for authentication (optional, uses session if omitted)",
+    },
+  },
 } as const;
 
 /** Tool config for status. */
@@ -41,15 +48,28 @@ export const STATUS_TOOL_CONFIG: {
   annotations: null,
 } as const;
 
+/// [MSG-PRIVACY] Issue #11: an agent may only see broadcasts plus its own
+/// (sent or received) messages. Direct messages addressed to other agents
+/// must never be returned by the status overview. A caller with no resolved
+/// identity (agentName === null) sees broadcasts only.
+const isVisibleTo: (message: Message, agentName: string | null) => boolean = (
+  message: Message,
+  agentName: string | null,
+): boolean =>
+  message.toAgent === BROADCAST_RECIPIENT ||
+  (agentName !== null && (message.toAgent === agentName || message.fromAgent === agentName));
+
 /** Create status tool handler. */
 export const createStatusHandler: (
   db: TooManyCooksDb,
   logger: Logger,
+  getSession?: SessionGetter,
 ) => ToolCallback = (
   db: TooManyCooksDb,
   logger: Logger,
+  getSession: SessionGetter = (): null => null,
 ): ToolCallback =>
-  {return async (): Promise<CallToolResult> => {
+  {return async (args: Record<string, unknown>): Promise<CallToolResult> => {
     const log: Logger = logger.child({ tool: "status" });
 
     const agentsResult: Result<readonly AgentIdentity[], DbError> = await db.listAgents();
@@ -66,7 +86,13 @@ export const createStatusHandler: (
 
     const messagesResult: Result<readonly Message[], DbError> = await db.listAllMessages();
     if (!messagesResult.ok) {return makeErrorResult(messagesResult.error);}
-    const messages: Array<Record<string, unknown>> = messagesResult.value.map(messageToJson);
+
+    // [MSG-PRIVACY] Issue #11: filter direct messages by resolved caller identity.
+    const identity: IdentityResult = await resolveIdentity(db, args, getSession);
+    const agentName: string | null = identity.isError ? null : identity.agentName;
+    const messages: Array<Record<string, unknown>> = messagesResult.value
+      .filter((message: Message): boolean => isVisibleTo(message, agentName))
+      .map(messageToJson);
 
     log.debug("Status queried");
 

--- a/too-many-cooks/packages/too-many-cooks/test/integration_test.ts
+++ b/too-many-cooks/packages/too-many-cooks/test/integration_test.ts
@@ -406,27 +406,39 @@ describe("Too Many Cooks MCP Server Integration", () => {
       });
     }
 
-    // Check status - MUST include messages!
+    // Check status as a known agent. [MSG-PRIVACY] Issue #11: status only
+    // returns messages visible to the caller (broadcasts + its own sent or
+    // received), so the ring of direct sends yields exactly the two that touch
+    // the viewer (one it sent, one it received).
+    const viewer = agents[0]!;
     const statusJson = JSON.parse(
-      await client.callTool("status", {}),
+      await client.callTool("status", { agent_key: viewer.key }),
     ) as Record<string, unknown>;
     assert.strictEqual((statusJson.agents as unknown[]).length, 5);
     assert.strictEqual((statusJson.locks as unknown[]).length, 5);
     assert.strictEqual((statusJson.plans as unknown[]).length, 5);
-    // CRITICAL: Status MUST return messages!
+    // CRITICAL: Status MUST include the messages field.
     assert.strictEqual(
       "messages" in statusJson,
       true,
       "Status response MUST include messages field",
     );
+    const msgs = statusJson.messages as Array<Record<string, unknown>>;
     assert.strictEqual(
-      (statusJson.messages as unknown[]).length,
-      5,
-      "Status MUST return all 5 messages sent",
+      msgs.length,
+      2,
+      "Status returns only the caller's own sent/received messages",
     );
+    // [MSG-PRIVACY] Issue #11: every returned message must involve the caller.
+    for (const m of msgs) {
+      assert.strictEqual(
+        m.to_agent === viewer.name || m.from_agent === viewer.name,
+        true,
+        "status must not leak messages unrelated to the caller",
+      );
+    }
 
     // Verify message structure
-    const msgs = statusJson.messages as Array<Record<string, unknown>>;
     const firstMsg = msgs[0]!;
     assert.ok("id" in firstMsg);
     assert.ok("from_agent" in firstMsg);

--- a/too-many-cooks/packages/too-many-cooks/test/status_handler_test.ts
+++ b/too-many-cooks/packages/too-many-cooks/test/status_handler_test.ts
@@ -76,7 +76,9 @@ describe("status handler", () => {
     await db.sendMessage(reg1.value.agentName, reg1.value.agentKey, reg2.value.agentName, "hello");
 
     const handler = createStatusHandler(db, createTestLogger());
-    const result = await handler({}, {});
+    // [MSG-PRIVACY] Issue #11: the direct message (reg1 -> reg2) is only visible
+    // to its recipient, so query status as reg2 to see it.
+    const result = await handler({ agent_key: reg2.value.agentKey }, {});
     assert.strictEqual(result.isError, false);
     const parsed = JSON.parse(result.content[0].text) as Record<string, unknown>;
     assert.strictEqual((parsed.agents as unknown[]).length, 2);

--- a/too-many-cooks/packages/too-many-cooks/test/status_message_privacy_test.ts
+++ b/too-many-cooks/packages/too-many-cooks/test/status_message_privacy_test.ts
@@ -1,0 +1,104 @@
+/// [MSG-PRIVACY] Issue #11: the `status` tool must NOT leak direct messages
+/// addressed to other agents. An agent calling `status` may only see
+/// broadcasts (to_agent = "*") plus its own inbox/sent messages.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import {
+  type TooManyCooksDb,
+  createDataConfig,
+  createLoggerWithContext,
+  createLoggingContext,
+  createStatusHandler,
+} from "too-many-cooks-core";
+import { createDb } from "../src/db-sqlite.js";
+
+const TEST_DB_PATH = ".test_status_message_privacy.db";
+const BROADCAST = "*";
+
+const deleteIfExists = (filePath: string): void => {
+  try {
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  } catch {
+    // Ignore
+  }
+};
+
+const createTestLogger = () =>
+  createLoggerWithContext(createLoggingContext());
+
+type StatusMessage = {
+  readonly content: string;
+};
+
+const statusMessagesFor = async (
+  db: TooManyCooksDb,
+  agentKey: string,
+): Promise<readonly StatusMessage[]> => {
+  const handler = createStatusHandler(db, createTestLogger());
+  const result = await handler({ agent_key: agentKey }, {});
+  assert.strictEqual(result.isError, false, "status must not error");
+  const parsed = JSON.parse(result.content[0].text) as { readonly messages: readonly StatusMessage[] };
+  return parsed.messages;
+};
+
+describe("status tool message privacy (#11)", () => {
+  let db: TooManyCooksDb | undefined;
+
+  beforeEach(() => {
+    deleteIfExists(TEST_DB_PATH);
+    const config = createDataConfig({ dbPath: TEST_DB_PATH });
+    const result = createDb(config);
+    assert.strictEqual(result.ok, true);
+    if (!result.ok) { throw new Error("expected ok db"); }
+    db = result.value;
+  });
+
+  afterEach(() => {
+    db?.close();
+    deleteIfExists(TEST_DB_PATH);
+  });
+
+  it("does not expose a direct message between two other agents to a third agent", async () => {
+    if (!db) { throw new Error("expected db"); }
+    const alice = await db.register("privacy-alice");
+    const bob = await db.register("privacy-bob");
+    const carol = await db.register("privacy-carol");
+    if (!alice.ok || !bob.ok || !carol.ok) { throw new Error("expected registrations ok"); }
+
+    const secret = "secret-for-bob-only";
+    const sent = await db.sendMessage(alice.value.agentName, alice.value.agentKey, bob.value.agentName, secret);
+    assert.strictEqual(sent.ok, true, "direct send must succeed");
+
+    const carolMessages = await statusMessagesFor(db, carol.value.agentKey);
+    assert.strictEqual(
+      carolMessages.some((m) => m.content === secret),
+      false,
+      "Carol must NOT see a direct message addressed to Bob",
+    );
+  });
+
+  it("still shows the recipient their own direct message and broadcasts to everyone", async () => {
+    if (!db) { throw new Error("expected db"); }
+    const alice = await db.register("privacy-alice2");
+    const bob = await db.register("privacy-bob2");
+    const carol = await db.register("privacy-carol2");
+    if (!alice.ok || !bob.ok || !carol.ok) { throw new Error("expected registrations ok"); }
+
+    const direct = "direct-to-bob";
+    const broadcast = "hello-everyone";
+    await db.sendMessage(alice.value.agentName, alice.value.agentKey, bob.value.agentName, direct);
+    await db.sendMessage(alice.value.agentName, alice.value.agentKey, BROADCAST, broadcast);
+
+    const bobMessages = await statusMessagesFor(db, bob.value.agentKey);
+    assert.strictEqual(bobMessages.some((m) => m.content === direct), true, "Bob must see his own direct message");
+    assert.strictEqual(bobMessages.some((m) => m.content === broadcast), true, "Bob must see the broadcast");
+
+    const carolMessages = await statusMessagesFor(db, carol.value.agentKey);
+    assert.strictEqual(carolMessages.some((m) => m.content === direct), false, "Carol must NOT see Bob's direct message");
+    assert.strictEqual(carolMessages.some((m) => m.content === broadcast), true, "Carol must see the broadcast");
+  });
+});

--- a/too_many_cooks_vscode_extension/src/services/connectionManager.ts
+++ b/too_many_cooks_vscode_extension/src/services/connectionManager.ts
@@ -82,15 +82,32 @@ interface ManagerState {
   target: ConnectionTarget | null;
 }
 
+/** Everything needed to spawn and reach the local server. */
+interface LocalServerSpec {
+  readonly bin: string;
+  readonly port: number;
+  readonly workspaceFolder: string;
+}
+
 /** Build the local base URL for a given port. */
 function buildLocalBaseUrl(port: number): string {
   return `${LOCAL_BASE_URL_PREFIX}${String(port)}`;
 }
 
-/** Poll until the local server responds on /admin/status. */
-async function pollUntilReady(baseUrl: string, log: LogFn): Promise<void> {
+/** Platform-aware spawn configuration for the local server (Issue #17).
+ *  On Windows the global npm bin is a `.cmd` shim that Node's spawn() can only
+ *  resolve via the shell; on posix the shell is unnecessary (and lets a missing
+ *  binary surface as an ENOENT 'error' event instead of a shell exit code). */
+export function buildLocalSpawnConfig(platform: NodeJS.Platform): { readonly shell: boolean } {
+  return { shell: platform === 'win32' };
+}
+
+/** Poll until the local server responds on /admin/status. Stops early if the
+ *  signal aborts (e.g. spawn failed first), so the loser of the startup race
+ *  does not keep polling a dead port. */
+async function pollUntilReady(baseUrl: string, log: LogFn, signal: AbortSignal): Promise<void> {
   const deadline: number = Date.now() + STARTUP_TIMEOUT_MS;
-  while (Date.now() < deadline) {
+  while (Date.now() < deadline && !signal.aborted) {
     const available: boolean = await checkServerAvailable(baseUrl);
     if (available) {
       log(`[ConnectionManager] Server ready at ${baseUrl}`);
@@ -100,16 +117,18 @@ async function pollUntilReady(baseUrl: string, log: LogFn): Promise<void> {
       setTimeout(resolve, POLL_INTERVAL_MS);
     });
   }
+  if (signal.aborted) { return; }
   throw new Error(`Local server did not start within ${String(STARTUP_TIMEOUT_MS)}ms`);
 }
 
 /** Spawn the too-many-cooks CLI as a child process. */
-function spawnLocalServer(port: number, workspaceFolder: string, log: LogFn): ChildProcess {
-  log(`[ConnectionManager] Spawning local server on port ${String(port)} (workspace: ${workspaceFolder})`);
-  const child: ChildProcess = spawn(LOCAL_SERVER_BIN, [], {
-    cwd: workspaceFolder,
+function spawnLocalServer(spec: LocalServerSpec, log: LogFn): ChildProcess {
+  log(`[ConnectionManager] Spawning local server '${spec.bin}' on port ${String(spec.port)} (workspace: ${spec.workspaceFolder})`);
+  const child: ChildProcess = spawn(spec.bin, [], {
+    cwd: spec.workspaceFolder,
     detached: false,
-    env: { ...process.env, [TMC_PORT_ENV]: String(port), [TMC_WORKSPACE_ENV]: workspaceFolder },
+    env: { ...process.env, [TMC_PORT_ENV]: String(spec.port), [TMC_WORKSPACE_ENV]: spec.workspaceFolder },
+    shell: buildLocalSpawnConfig(process.platform).shell,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   child.stderr?.on('data', (data: Buffer): void => {
@@ -119,6 +138,26 @@ function spawnLocalServer(port: number, workspaceFolder: string, log: LogFn): Ch
     log(`[ConnectionManager] Local server exited (code: ${String(code)})`);
   });
   return child;
+}
+
+/** Resolve once the server is ready, or reject promptly if the child fails to
+ *  spawn (ENOENT 'error'). Without this the failure is swallowed and the user
+ *  only sees the misleading generic startup timeout. Issue #17. */
+async function awaitServerReady(child: ChildProcess, spec: LocalServerSpec, log: LogFn): Promise<void> {
+  const controller: AbortController = new AbortController();
+  const failure: Promise<never> = new Promise<never>(
+    (_resolve: (value: never) => void, reject: (reason: Error) => void): void => {
+      child.once('error', (err: Error): void => {
+        reject(new Error(`Local server '${spec.bin}' could not be started: ${err.message}`));
+      });
+    },
+  );
+  try {
+    await Promise.race([pollUntilReady(buildLocalBaseUrl(spec.port), log, controller.signal), failure]);
+  } finally {
+    controller.abort();
+    child.removeAllListeners('error');
+  }
 }
 
 /** Kill a child process with SIGTERM, escalating to SIGKILL after grace period. */
@@ -154,7 +193,7 @@ async function validateCloudCredentials(target: CloudTarget, log: LogFn): Promis
 }
 
 /** Create a connection manager instance. */
-export function createConnectionManager(workspaceFolder: string, log: LogFn): ConnectionManager {
+export function createConnectionManager(workspaceFolder: string, log: LogFn, serverBin: string = LOCAL_SERVER_BIN): ConnectionManager {
   const state: ManagerState = {
     localProcess: null,
     mode: 'disconnected',
@@ -173,9 +212,10 @@ export function createConnectionManager(workspaceFolder: string, log: LogFn): Co
 
   async function startLocal(port: number = DEFAULT_LOCAL_PORT): Promise<void> {
     if (state.mode !== 'disconnected') { disconnect(); }
-    const child: ChildProcess = spawnLocalServer(port, workspaceFolder, log);
+    const spec: LocalServerSpec = { bin: serverBin, port, workspaceFolder };
+    const child: ChildProcess = spawnLocalServer(spec, log);
     state.localProcess = child;
-    await pollUntilReady(buildLocalBaseUrl(port), log);
+    await awaitServerReady(child, spec, log);
     Object.assign(state, { mode: 'local' satisfies ConnectionMode, target: { mode: 'local', port, transport: LOCAL_TRANSPORT } satisfies LocalTarget });
   }
 

--- a/too_many_cooks_vscode_extension/src/state/selectors.ts
+++ b/too_many_cooks_vscode_extension/src/state/selectors.ts
@@ -1,9 +1,26 @@
 // Derived state selectors.
 
 import type { AgentDetails, AgentIdentity, AgentPlan, AppState, ConnectionStatus, FileLock, Message } from './types';
+import type { ConnectionTarget } from '../services/connectionTypes';
+
+/** Connection mode labels shown in the status bar. */
+export const MODE_LOCAL: string = 'Local/HTTP';
+export const MODE_CLOUD_STDIO: string = 'Cloud/stdio';
+export const MODE_CLOUD_HTTP: string = 'Cloud/HTTP';
+export const MODE_DISCONNECTED: string = 'Disconnected';
 
 export function selectConnectionStatus(state: Readonly<AppState>): ConnectionStatus {
   return state.connectionStatus;
+}
+
+/** Status-bar mode label for the current connection status and target.
+ *  Issue #12: a live connection with no explicit target is, by construction,
+ *  the default local server (cloud always sets a target via the picker), so it
+ *  must read as the local mode — never "Disconnected" while connected. */
+export function selectModeLabel(status: ConnectionStatus, target: ConnectionTarget | null): string {
+  if (status !== 'connected') { return MODE_DISCONNECTED; }
+  if (target === null || target.mode === 'local') { return MODE_LOCAL; }
+  return target.transport === 'stdio' ? MODE_CLOUD_STDIO : MODE_CLOUD_HTTP;
 }
 
 export function selectAgents(state: Readonly<AppState>): readonly AgentIdentity[] {

--- a/too_many_cooks_vscode_extension/src/ui/statusBar.ts
+++ b/too_many_cooks_vscode_extension/src/ui/statusBar.ts
@@ -6,31 +6,17 @@
 
 import * as vscode from 'vscode';
 import type { AppState, ConnectionStatus } from '../state/types';
-import { selectAgentCount, selectConnectionStatus, selectLockCount, selectUnreadMessageCount } from '../state/selectors';
+import { selectAgentCount, selectConnectionStatus, selectLockCount, selectModeLabel, selectUnreadMessageCount } from '../state/selectors';
 import type { StoreManager } from '../services/storeManager';
 
 /** Status bar command — opens connection picker. */
 const STATUS_BAR_COMMAND: string = 'tooManyCooks.chooseConnection';
-
-/** Mode labels for status bar display. */
-const MODE_LOCAL: string = 'Local/HTTP';
-const MODE_CLOUD_STDIO: string = 'Cloud/stdio';
-const MODE_CLOUD_HTTP: string = 'Cloud/HTTP';
-const MODE_DISCONNECTED: string = 'Disconnected';
 
 function pluralSuffix(count: number): string {
   if (count === 1) {
     return '';
   }
   return 's';
-}
-
-/** Get display label for the current connection mode + transport. */
-function getModeLabel(storeManager: Readonly<StoreManager>): string {
-  const target: ReturnType<typeof storeManager.getTarget> = storeManager.getTarget();
-  if (target === null) { return MODE_DISCONNECTED; }
-  if (target.mode === 'local') { return MODE_LOCAL; }
-  return target.transport === 'stdio' ? MODE_CLOUD_STDIO : MODE_CLOUD_HTTP;
 }
 
 export class StatusBarManager {
@@ -81,7 +67,7 @@ export class StatusBarManager {
     const agents: number = selectAgentCount(state);
     const locks: number = selectLockCount(state);
     const unread: number = selectUnreadMessageCount(state);
-    const modeLabel: string = getModeLabel(storeManager);
+    const modeLabel: string = selectModeLabel(selectConnectionStatus(state), storeManager.getTarget());
     this.statusBarItem.text =
       `$(check) TMC: ${modeLabel}  $(person) ${String(agents)}  $(lock) ${String(locks)}  $(mail) ${String(unread)}`;
     this.statusBarItem.tooltip = [

--- a/too_many_cooks_vscode_extension/test/pure/connectionManager.test.ts
+++ b/too_many_cooks_vscode_extension/test/pure/connectionManager.test.ts
@@ -108,14 +108,16 @@ describe('ConnectionManager', () => {
       const { log, logs } = createLogCollector();
       const cm: ConnectionManager = createConnectionManager('/tmp/tmc-test', log);
 
-      // Port 1 is privileged and won't work, server won't start in time
+      // Port 1 is privileged and won't work; either the spawn fails fast
+      // (binary not resolvable -> ENOENT, Issue #17) or the server never binds
+      // and the startup poll times out. Both are valid startup failures.
       try {
         await cm.startLocal(1);
         assert.fail('Must throw when server cannot start');
       } catch (err: unknown) {
         assert.ok(err instanceof Error, 'Must throw an Error');
         assert.ok(
-          err.message.includes('did not start'),
+          err.message.includes('did not start') || err.message.includes('could not be started'),
           `Error must mention startup failure: ${err.message}`,
         );
       }

--- a/too_many_cooks_vscode_extension/test/pure/connectionManagerSpawn.test.ts
+++ b/too_many_cooks_vscode_extension/test/pure/connectionManagerSpawn.test.ts
@@ -1,0 +1,58 @@
+/// ConnectionManager local-server spawn-failure tests — Issue #17.
+///
+/// On Windows the global npm bin is a `.cmd` shim that Node's spawn() can only
+/// resolve via the shell; without it spawn() fails with ENOENT. Previously the
+/// 'error' event was never handled, so the failure was swallowed and the user
+/// only ever saw the misleading generic "did not start within 15000ms" timeout.
+///
+/// These tests inject a guaranteed-nonexistent binary to prove the spawn
+/// failure is surfaced promptly with a descriptive error, and that the spawn
+/// is configured to use the shell on Windows so the `.cmd` shim resolves.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { buildLocalSpawnConfig, createConnectionManager } from '../../src/services/connectionManager';
+import type { ConnectionManager } from '../../src/services/connectionManager';
+
+const NONEXISTENT_BIN: string = '/nonexistent/tmc-server-does-not-exist-zzz';
+const TEST_PORT: number = 4099;
+const GENERIC_TIMEOUT_FRAGMENT: string = 'did not start within';
+
+const createLogCollector = (): { readonly logs: string[]; readonly log: (msg: string) => void } => {
+  const logs: string[] = [];
+  return { logs, log: (msg: string): void => { logs.push(msg); } };
+};
+
+describe('ConnectionManager local server spawn failure (#17)', () => {
+  it('surfaces a descriptive spawn error instead of swallowing it and timing out', async () => {
+    const { log, logs } = createLogCollector();
+    const cm: ConnectionManager = createConnectionManager('/tmp/tmc-test', log, NONEXISTENT_BIN);
+
+    await assert.rejects(
+      cm.startLocal(TEST_PORT),
+      (err: unknown): boolean => {
+        assert.ok(err instanceof Error, 'must reject with an Error');
+        assert.ok(
+          !err.message.includes(GENERIC_TIMEOUT_FRAGMENT),
+          `spawn failure must not be masked by the generic startup timeout: ${err.message}`,
+        );
+        assert.ok(
+          err.message.includes(NONEXISTENT_BIN) || /ENOENT|could not be started/i.test(err.message),
+          `error must describe the spawn failure: ${err.message}`,
+        );
+        return true;
+      },
+    );
+
+    assert.ok(
+      logs.some((l: string) => l.includes('Spawning local server')),
+      'must log the spawn attempt',
+    );
+  });
+
+  it('uses the shell on Windows so the .cmd shim resolves, but not on posix', () => {
+    assert.strictEqual(buildLocalSpawnConfig('win32').shell, true, 'Windows must spawn via shell to find the .cmd shim');
+    assert.strictEqual(buildLocalSpawnConfig('darwin').shell, false, 'macOS does not need the shell');
+    assert.strictEqual(buildLocalSpawnConfig('linux').shell, false, 'Linux does not need the shell');
+  });
+});

--- a/too_many_cooks_vscode_extension/test/pure/statusBarModeLabel.test.ts
+++ b/too_many_cooks_vscode_extension/test/pure/statusBarModeLabel.test.ts
@@ -1,0 +1,48 @@
+/// Status-bar mode label — Issue #12.
+///
+/// When the extension auto-connects (restore on activation) the connection
+/// picker is bypassed, so StoreManager.getTarget() stays null even though the
+/// connection is live. The status bar must still read the live mode, NOT
+/// "Disconnected" (cloud always sets a target via the picker, so connected +
+/// null target is, by construction, the default local server).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  MODE_CLOUD_HTTP,
+  MODE_CLOUD_STDIO,
+  MODE_DISCONNECTED,
+  MODE_LOCAL,
+  selectModeLabel,
+} from '../../src/state/selectors';
+import type { CloudTarget, LocalTarget } from '../../src/services/connectionTypes';
+
+const LOCAL_TARGET: LocalTarget = { mode: 'local', port: 4040, transport: 'http-streamable' };
+const CLOUD_STDIO_TARGET: CloudTarget = {
+  apiKey: 'k',
+  apiUrl: 'https://api',
+  mode: 'cloud',
+  passphrase: 'p',
+  tenantId: 't',
+  transport: 'stdio',
+  workspaceId: 'w',
+};
+const CLOUD_HTTP_TARGET: CloudTarget = { ...CLOUD_STDIO_TARGET, transport: 'http-streamable' };
+
+describe('selectModeLabel (#12)', () => {
+  it('shows the live mode when connected without an explicit target (auto-connect)', () => {
+    assert.strictEqual(selectModeLabel('connected', null), MODE_LOCAL);
+    assert.notStrictEqual(selectModeLabel('connected', null), MODE_DISCONNECTED);
+  });
+
+  it('labels explicit local and cloud targets correctly', () => {
+    assert.strictEqual(selectModeLabel('connected', LOCAL_TARGET), MODE_LOCAL);
+    assert.strictEqual(selectModeLabel('connected', CLOUD_STDIO_TARGET), MODE_CLOUD_STDIO);
+    assert.strictEqual(selectModeLabel('connected', CLOUD_HTTP_TARGET), MODE_CLOUD_HTTP);
+  });
+
+  it('reads Disconnected only when actually not connected', () => {
+    assert.strictEqual(selectModeLabel('disconnected', null), MODE_DISCONNECTED);
+    assert.strictEqual(selectModeLabel('connecting', null), MODE_DISCONNECTED);
+  });
+});


### PR DESCRIPTION
Fixes the three most critical open bugs, each via strict **test-first TDD** (a failing test was written and confirmed to fail *because of the bug*, then the minimal fix was applied).

## #11 — Direct messages leak to all agents (privacy/security) 🔴
The `status` MCP tool called `db.listAllMessages()` and returned **every** message — including direct messages between *other* agents — to any caller, with no identity filtering.

**Fix:** `status` now resolves the caller's identity (`agent_key` arg or session) and returns only broadcasts (`*`) plus the caller's own sent/received messages. Anonymous callers see broadcasts only. Tagged `[MSG-PRIVACY]`.
- `packages/core/src/tools/status_tool.ts`, `packages/core/src/server.ts`
- New test: `test/status_message_privacy_test.ts`; pre-existing tests that asserted the leak updated to assert correct privacy.

## #17 — Windows local server fails to start; ENOENT swallowed 🔴
`spawn()` ran with no shell, so Node couldn't resolve the global npm `.cmd` shim on Windows, and the `'error'` event was never handled — so the real ENOENT was swallowed and users only saw the misleading `Local server did not start within 15000ms`.

**Fix:** spawn via the shell on Windows (`buildLocalSpawnConfig`) so the `.cmd` shim resolves, and surface spawn failures promptly via a cancellable readiness race instead of the generic timeout.
- `src/services/connectionManager.ts`
- New test: `test/pure/connectionManagerSpawn.test.ts`

## #12 — Status bar shows "TMC: Disconnected" while connected
The mode label equated a `null` connection target with "disconnected", but the auto-connect (restore-on-activation) path never calls `setTarget`, so the target stayed `null` while live.

**Fix:** a connected manager with no explicit target is, by construction, the default local server (cloud always sets a target via the picker), so the label is now derived from connection status in a pure, centralized `selectModeLabel` selector.
- `src/state/selectors.ts`, `src/ui/statusBar.ts`
- New test: `test/pure/statusBarModeLabel.test.ts`

## Verification
- MCP server: `npm run build`, `npm run lint`, `npm test` → **363/363 pass**
- Extension: compile, `npm run lint`, pure tests + coverage → **156/156 pass, 93.18%** (threshold 80%)
- `make lint` clean across both packages
- No test was skipped, deleted, or had assertions removed.

Closes #11
Closes #12
Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)