### PR TITLE
Fix #33: never kill another process — per-folder isolation + step aside on port conflict

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,6 +1,6 @@
 # Too Many Cooks - Multi-Agent Coordination MCP Server
 
-CRITICAL: THERE IS ONLY ONE SERVER. IT SERVES BOTH MCP and ADMIN ROUTES.
+CRITICAL: THERE IS ONLY ONE SERVER **PER WORKSPACE FOLDER**. IT SERVES BOTH MCP and ADMIN ROUTES. One folder → exactly one server. Two folders → two independent servers that **never** touch each other's port, process, database, or logs. See [Server Lifecycle & Process Isolation](#server-lifecycle--process-isolation).
 
 ## Overview
 
@@ -43,6 +43,66 @@ ONE HTTP server:
 **Why HTTP, not stdio**: Stdio spawns an isolated process per agent — agents can't see each other's events. HTTP gives one shared process where the notification emitter actually works across all connected agents.
 
 **Cloud mode**: In cloud mode (TMC Cloud), agents connect via **stdio** instead. Each agent launches its own server process, but since the backend is remote (Supabase), there's no shared local state to worry about. The VSIX manages MCP config for all major agents (Claude Code, Codex, Cline, etc.) and handles switching between local/cloud automatically. See `tmc-cloud/tmc-cloud-technical-spec.md` for details.
+
+---
+
+## Server Lifecycle & Process Isolation
+
+> **The cardinal rule: a Too Many Cooks process NEVER interferes with another process.** It does not kill it, signal it, or take its port. Isolation is by **workspace folder**. This section is non-negotiable and is enforced by tests. Spec IDs below are referenced from the code and tests (`grep [SERVER-`).
+
+The server's workspace folder is `TMC_WORKSPACE` (falling back to `process.cwd()`), and its port is `TMC_PORT` (falling back to `4040`). Everything that follows is keyed off that one folder.
+
+### `[SERVER-NO-KILL]` — Never kill another process
+
+The server **MUST NOT** run `lsof`, `kill`, `kill -9`, `taskkill`, `process.kill(pid, <signal>)`, or any other mechanism that terminates or signals a process it did not itself spawn. There is no "port takeover". If a port is occupied, the owner is left **completely untouched** — it may belong to a different project, a different tool, or nothing to do with Too Many Cooks at all. Killing it is data loss for someone else.
+
+> The only permitted use of `process.kill` is the **signal-0 liveness probe** (`process.kill(pid, 0)`), which sends no signal and only asks "does this PID exist?". It is used by `[SERVER-LOCKFILE]` to detect stale locks and never to terminate anything.
+
+### `[SERVER-SINGLE-INSTANCE]` — One server per folder; refuse a second
+
+Before binding its port, the server checks the per-folder lock file (`[SERVER-LOCKFILE]`). If a **live** Too Many Cooks process already holds the lock for this workspace folder, the new process **immediately exits with a non-zero code** and logs a clear error:
+
+> `Too Many Cooks is already running in this folder — refusing to start a second instance.` (including the existing PID and port).
+
+This is the single source of truth for "is TMC already running here". It does not depend on the port, so it catches the case where a second instance is told to use a *different* port in the *same* folder — that is still forbidden, because both would write to the same `.too_many_cooks/data.db` and the same logs.
+
+### `[SERVER-PORT-CONFLICT]` — Step aside cleanly on `EADDRINUSE`
+
+`app.listen(port)` MUST have an `'error'` handler. If binding fails with `EADDRINUSE`, the server logs a clear error and **exits cleanly with a non-zero code** — it never tries to free the port by force (`[SERVER-NO-KILL]`):
+
+> `Port <port> is already in use by another process — stepping aside. Too Many Cooks never kills the process holding a port. Set TMC_PORT to run on a different port.`
+
+To run Too Many Cooks for two folders at once, give each folder its own port via `TMC_PORT` (or the `tooManyCooks.port` VS Code setting). The default `4040` is shared, so the second folder on the default port will step aside until it is given a distinct port.
+
+### `[SERVER-STATE-ISOLATION]` — All state lives in `.too_many_cooks/`
+
+**Every** byte of per-workspace state lives under `${workspaceFolder}/.too_many_cooks/` and nowhere else:
+
+| State | Path |
+|-------|------|
+| Database | `${workspaceFolder}/.too_many_cooks/data.db` |
+| Logs | `${workspaceFolder}/.too_many_cooks/logs/mcp-server-<timestamp>.log` |
+| Single-instance lock | `${workspaceFolder}/.too_many_cooks/server.lock` |
+
+Because the folder *is* the isolation boundary, no other instance can read or corrupt this state — a second instance is refused before it ever opens the database (`[SERVER-SINGLE-INSTANCE]`). State is **never** written to `~/`, `/tmp`, the package directory, or a bare `logs/` folder.
+
+### `[SERVER-LOCKFILE]` — The single-instance lock file
+
+`server.lock` is JSON: `{ "pid": <number>, "port": <number>, "startedAt": <epoch-ms> }`.
+
+- **On startup**: read `server.lock`. If it exists and its `pid` is alive (signal-0 probe), the folder is busy → refuse (`[SERVER-SINGLE-INSTANCE]`). If it is missing, unparseable, or its `pid` is dead (a **stale** lock left by a crash / `kill -9`), overwrite it with our own `{pid, port, startedAt}` and continue.
+- **On shutdown** (`SIGTERM`, `SIGINT`, or normal `exit`): delete `server.lock`, but **only if it still records our own PID** — never remove a lock another instance has since taken.
+
+Stale-lock recovery is mandatory: a server that was `SIGKILL`ed leaves a lock behind, and the next start in that folder must reclaim it.
+
+### `[SERVER-EPIPE]` — A broken pipe must never loop into the logger
+
+A dead `stdout`/`stderr` pipe (e.g. the parent editor went away) is **unrecoverable, not fatal-loopable**. The server MUST:
+
+- attach an `'error'` listener to `process.stdout` and `process.stderr` that swallows `EPIPE` (without a listener, an `EPIPE` becomes an `uncaughtException`);
+- in the `uncaughtException`/`unhandledRejection` handlers, **not** re-enter the logger for an `EPIPE` error (writing the "fatal" line to the same broken stream is what produced the multi-gigabyte log in issue #33).
+
+Defense in depth: even one un-guarded write to a dead pipe must not be able to start an unbounded `EPIPE → log.fatal → EPIPE` loop.
 
 ---
 
@@ -244,6 +304,9 @@ Admin operations are exposed as REST endpoints on the server, **not** as MCP too
 
 | Setting | Value |
 |---------|-------|
+| Server port (`TMC_PORT`) | 4040 (one port per folder; never taken by force — see `[SERVER-PORT-CONFLICT]`) |
+| Workspace folder (`TMC_WORKSPACE`) | `process.cwd()` |
+| State directory | `${workspaceFolder}/.too_many_cooks/` (db, logs, lock — see `[SERVER-STATE-ISOLATION]`) |
 | Lock timeout | 600000ms (10 min) |
 | Max message length | 200 chars |
 | Max plan field length | 100 chars |
@@ -262,3 +325,5 @@ Black-box, end-to-end tests. Interact via MCP protocol (HTTP) or VSCode UI, veri
 | MCP server (integration) | `too-many-cooks/test/` |
 | Tool schemas | `too-many-cooks/test/tool_schemas_test.ts` |
 | VSCode extension | `too_many_cooks_vscode_extension/test/suite/` |
+| Process isolation `[SERVER-NO-KILL]` / `[SERVER-PORT-CONFLICT]` | `too-many-cooks/test/server_no_cross_kill_test.ts` |
+| Single instance per folder `[SERVER-SINGLE-INSTANCE]` | `too-many-cooks/test/server_single_instance_test.ts` |

--- a/too-many-cooks/CHANGELOG.md
+++ b/too-many-cooks/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.13.0
+
+### Fixed
+- **Two VS Code windows no longer collide on the shared port (#33).** A second server starting on an occupied port used to run `lsof -ti` + `kill -9` and terminate whatever owned the port — including a *different project's* server, which then EPIPE-looped into a multi-gigabyte log that could crash the editor.
+
+### Changed
+- **Process isolation is now by workspace folder, and the server NEVER kills another process** (`[SERVER-NO-KILL]`). The "port auto-kill on startup" behavior added in 0.4.0 is **removed**.
+- **One server per folder** (`[SERVER-SINGLE-INSTANCE]`): a second start in the same folder exits immediately with `Too Many Cooks is already running in this folder`, guarded by a `.too_many_cooks/server.lock` file (`[SERVER-LOCKFILE]`).
+- **Port conflicts step aside cleanly** (`[SERVER-PORT-CONFLICT]`): an `EADDRINUSE` now produces a graceful non-zero exit instead of killing the port owner. Use a distinct `TMC_PORT` per folder to run several at once.
+- **All per-workspace state (database, logs, lock) lives under `${workspace}/.too_many_cooks/`** (`[SERVER-STATE-ISOLATION]`).
+
+### Hardened
+- A broken `stdout`/`stderr` pipe can no longer loop into the logger and balloon the log file (`[SERVER-EPIPE]`).
+
 ## 0.4.0
 
 ### Added

--- a/too-many-cooks/packages/too-many-cooks/bin/server.ts
+++ b/too-many-cooks/packages/too-many-cooks/bin/server.ts
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
 /// Entry point for Too Many Cooks MCP server.
 ///
-/// Starts a single Express HTTP server on port 4040 with:
+/// Starts ONE Express HTTP server per workspace folder (default port 4040) with:
 /// - `/mcp` — MCP Streamable HTTP for agent connections
 /// - `/admin/*` — REST + Streamable HTTP for the VSCode extension
+///
+/// Process isolation is by folder and the server NEVER kills another process:
+/// - [SERVER-SINGLE-INSTANCE] refuse to start if TMC already runs in this folder
+/// - [SERVER-PORT-CONFLICT] step aside cleanly on EADDRINUSE (never kill the owner)
+/// - [SERVER-STATE-ISOLATION] all state lives in `${workspace}/.too_many_cooks/`
+/// - [SERVER-EPIPE] a dead stdio pipe can never loop into the logger
 ///
 /// Implements the deploy-toolkit `--version` contract before anything else.
 
@@ -34,8 +40,7 @@
 }
 
 import crypto from "node:crypto";
-import { execSync } from "node:child_process";
-import net from "node:net";
+import type { Server } from "node:http";
 import express, { type Request, type Response } from "express";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -44,17 +49,26 @@ import {
   type AdminEventHub,
   type AgentEventHub,
   type Logger,
+  type Result,
   type TooManyCooksDb,
   createAdminEventHub,
   createAgentEventHub,
   createMcpServerForDb,
   defaultConfig,
   getServerPort,
+  getWorkspaceFolder,
   registerAdminRoutes,
 } from "too-many-cooks-core";
 
 import { createBackend } from "../src/backend.js";
 import { createLogger } from "./logger.js";
+import {
+  type LockOutcome,
+  acquireServerLock,
+  errorCode,
+  releaseServerLock,
+  resolveLockPath,
+} from "./server_lock.js";
 
 /** JSON-RPC bad request error response. */
 const BAD_REQUEST_JSON: string =
@@ -64,7 +78,18 @@ const BAD_REQUEST_JSON: string =
 const SESSION_NOT_FOUND_JSON: string =
   '{"jsonrpc":"2.0","error":{"code":-32001,"message":"Session not found"},"id":null}';
 
+/// [SERVER-EPIPE] A dead stdout/stderr pipe is unrecoverable, not fatal-loopable.
+/// Without an 'error' listener an EPIPE surfaces as an uncaughtException, which
+/// used to re-enter the logger and write the "fatal" line to the same broken
+/// stream forever — the multi-gigabyte log loop in issue #33. Consume it here.
+const installPipeGuards: () => void = (): void => {
+  const swallow: () => void = (): void => { /* a broken stdio pipe is not recoverable */ };
+  process.stdout.on("error", swallow);
+  process.stderr.on("error", swallow);
+};
+
 const installProcessHandlers: (log: Logger) => void = (log: Logger): void => {
+  installPipeGuards();
   const shutdown: (signal: string) => void = (signal: string): void => {
     log.info("Server shutting down", { signal });
     process.exit(0);
@@ -72,6 +97,7 @@ const installProcessHandlers: (log: Logger) => void = (log: Logger): void => {
   process.on("SIGTERM", (): void => { shutdown("SIGTERM"); });
   process.on("SIGINT", (): void => { shutdown("SIGINT"); });
   process.on("uncaughtException", (err: Error): void => {
+    if (errorCode(err) === "EPIPE") {return;} // [SERVER-EPIPE] never re-enter the logger on a dead pipe
     log.fatal("Uncaught exception", { error: String(err), stack: err.stack ?? "" });
   });
   process.on("unhandledRejection", (reason: unknown): void => {
@@ -83,65 +109,63 @@ const main: () => Promise<void> = async (): Promise<void> => {
   const log: Logger = createLogger();
   installProcessHandlers(log);
   log.info("Server starting...");
+  const workspace: string = getWorkspaceFolder();
+  const port: number = getServerPort();
+  const lockPath: string = resolveLockPath(workspace);
+  guardSingleInstance(lockPath, workspace, port, log);
+  process.on("exit", (): void => { releaseServerLock(lockPath); });
   try {
-    await startServer(log);
+    await startServer(log, port);
   } catch (e) {
     log.fatal("Fatal error", { error: String(e) });
     throw e;
   }
 };
 
-/** Maximum time to wait for port to become free after killing a process. */
-const PORT_FREE_TIMEOUT_MS: number = 5000;
-
-/** Timeout for port check connection attempt (ms). */
-const PORT_CHECK_TIMEOUT_MS: number = 500;
-
-/** Delay between port-free polls in milliseconds. */
-const PORT_POLL_DELAY_MS: number = 100;
-
-/** Perform a raw TCP probe and return a Promise<boolean> (non-async to avoid require-await). */
-// eslint-disable-next-line @typescript-eslint/promise-function-async
-const tcpProbe: (port: number) => Promise<boolean> = (port: number): Promise<boolean> =>
-  new Promise((resolve: (value: boolean) => void): void => {
-    const socket: net.Socket = net.createConnection({ port, host: "127.0.0.1" });
-    const timer: NodeJS.Timeout = setTimeout((): void => { socket.destroy(); resolve(false); }, PORT_CHECK_TIMEOUT_MS);
-    socket.once("connect", (): void => { clearTimeout(timer); socket.destroy(); resolve(true); });
-    socket.once("error", (): void => { clearTimeout(timer); resolve(false); });
-  });
-
-/** Check whether a port is in use by attempting a TCP connection. */
-const isPortInUse: (port: number) => Promise<boolean> = async (port: number): Promise<boolean> =>
-  await tcpProbe(port);
-
-/** Kill any existing process listening on the given port and wait for it to be freed. */
-const killExistingProcess: (port: number, log: Logger) => Promise<void> = async (port: number, log: Logger): Promise<void> => {
-  const inUse: boolean = await isPortInUse(port);
-  if (!inUse) {return;}
-  log.info("Port in use, killing existing process", { port });
-  try {
-    const output: string = execSync(`lsof -ti :${String(port)}`, { encoding: "utf8" }).trim();
-    if (output.length === 0) {return;}
-    const pids: readonly string[] = output.split("\n").map((pid: string): string => {return pid.trim()}).filter((pid: string): boolean => {return pid.length > 0});
-    for (const pid of pids) {
-      log.info("Killing process", { port, pid });
-      execSync(`kill -9 ${pid}`);
-    }
-    const start: number = Date.now();
-    while (Date.now() - start < PORT_FREE_TIMEOUT_MS) {
-      if (!(await isPortInUse(port))) {
-        log.info("Port is now free", { port });
-        return;
-      }
-      await new Promise((resolve: (value: undefined) => void): void => { setTimeout((): void => {resolve(undefined);}, PORT_POLL_DELAY_MS); });
-    }
-    log.warn("Port still in use after timeout — proceeding anyway", { port });
-  } catch {
-    // Lsof exits non-zero when no process found — that's fine
+/// [SERVER-SINGLE-INSTANCE] Claim this workspace folder, or exit cleanly if another
+/// LIVE Too Many Cooks already owns it. The other process is left completely
+/// untouched — we never kill it ([SERVER-NO-KILL]).
+const guardSingleInstance: (lockPath: string, workspace: string, port: number, log: Logger) => void = (
+  lockPath: string,
+  workspace: string,
+  port: number,
+  log: Logger,
+): void => {
+  const result: Result<LockOutcome, string> = acquireServerLock(lockPath, port, Date.now());
+  if (!result.ok) {
+    log.fatal("Could not acquire single-instance lock", { workspace, error: result.error });
+    process.exit(1);
   }
+  if (result.value.kind === "busy") {
+    log.error(
+      "Too Many Cooks is already running in this folder — refusing to start a second instance",
+      { workspace, existingPid: result.value.existing.pid, existingPort: result.value.existing.port },
+    );
+    process.exit(1);
+  }
+  log.info("Acquired single-instance lock", { workspace, port });
 };
 
-const startServer: (log: Logger) => Promise<void> = async (log: Logger): Promise<void> => {
+/// [SERVER-PORT-CONFLICT] If the port is taken, step aside cleanly. Too Many Cooks
+/// NEVER kills the process holding a port ([SERVER-NO-KILL]) — run a different
+/// folder on a different TMC_PORT instead.
+const handleListenError: (err: Error, port: number, log: Logger) => void = (
+  err: Error,
+  port: number,
+  log: Logger,
+): void => {
+  if (errorCode(err) === "EADDRINUSE") {
+    log.error(
+      "Port already in use by another process — stepping aside (Too Many Cooks never kills the process holding a port). Set TMC_PORT to run on a different port.",
+      { port },
+    );
+    process.exit(1);
+  }
+  log.fatal("Server listen error", { port, error: String(err) });
+  process.exit(1);
+};
+
+const startServer: (log: Logger, port: number) => Promise<void> = async (log: Logger, port: number): Promise<void> => {
   log.info("Creating server...");
 
   const cfg: typeof defaultConfig = defaultConfig;
@@ -170,11 +194,11 @@ const startServer: (log: Logger) => Promise<void> = async (log: Logger): Promise
   app.get("/mcp", asyncHandler(mcpGetDeleteHandler(transports, agentHub), log));
   app.delete("/mcp", asyncHandler(mcpGetDeleteHandler(transports, agentHub), log));
 
-  const port: number = getServerPort();
-  await killExistingProcess(port, log);
-  app.listen(port, (): void => {
+  const server: Server = app.listen(port, (): void => {
     log.info("Server listening", { port });
   });
+  // [SERVER-PORT-CONFLICT] Never crash unhandled on a busy port — step aside.
+  server.on("error", (err: Error): void => { handleListenError(err, port, log); });
 
   // Keep event loop alive
   const KEEP_ALIVE_INTERVAL_MS: number = 60000;

--- a/too-many-cooks/packages/too-many-cooks/bin/server_lock.ts
+++ b/too-many-cooks/packages/too-many-cooks/bin/server_lock.ts
@@ -1,0 +1,128 @@
+/// Per-folder single-instance lock for the Too Many Cooks server.
+///
+/// Spec: docs/spec.md [SERVER-SINGLE-INSTANCE], [SERVER-LOCKFILE], [SERVER-NO-KILL].
+///
+/// This lives in the LOCAL server package (not shared core) on purpose: the lock
+/// is process-local (it uses `process.pid`/`process.kill`) and only the local
+/// SQLite server needs it — the cloud backend is remote and stateless. Shipping
+/// it here also means the published bin never depends on a newer core release.
+///
+/// The lock is a JSON file in the workspace's `.too_many_cooks/` directory — the
+/// same directory the database lives in (derived via core's `resolveDbPath`). It
+/// answers "is Too Many Cooks already running in THIS folder?" without depending
+/// on the port, because two instances in one folder would share one database.
+
+import fs from "node:fs";
+import path from "node:path";
+import { type Result, error, resolveDbPath, success } from "too-many-cooks-core";
+
+/** Lock file name inside the `.too_many_cooks` state directory. [SERVER-LOCKFILE] */
+const LOCK_FILE_NAME: string = "server.lock";
+
+/** Shape of the persisted lock file. [SERVER-LOCKFILE] */
+export type ServerLock = {
+  readonly pid: number;
+  readonly port: number;
+  readonly startedAt: number;
+};
+
+/** Outcome of trying to claim the folder. */
+export type LockOutcome =
+  | { readonly kind: "acquired"; readonly path: string }
+  | { readonly kind: "busy"; readonly path: string; readonly existing: ServerLock };
+
+/**
+ * Resolve the lock file path for a workspace folder. Reuses core's database-path
+ * logic so the lock always sits next to `data.db` in `.too_many_cooks/`.
+ * [SERVER-STATE-ISOLATION]
+ */
+export const resolveLockPath: (workspaceFolder: string) => string = (workspaceFolder: string): string =>
+  {return path.join(path.dirname(resolveDbPath(workspaceFolder)), LOCK_FILE_NAME)};
+
+/** Read the `code` field off an unknown thrown value without a type assertion. */
+export const errorCode: (e: unknown) => string | undefined = (e: unknown): string | undefined =>
+  typeof e === "object" && e !== null && "code" in e && typeof e.code === "string"
+    ? e.code
+    : undefined;
+
+/**
+ * Is a process with this PID currently alive? `process.kill(pid, 0)` sends NO
+ * signal — it only probes existence ([SERVER-NO-KILL]: we never terminate anything).
+ * `EPERM` means the process exists but is owned by someone else → still alive.
+ */
+const isPidAlive: (pid: number) => boolean = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: unknown) {
+    return errorCode(e) === "EPERM";
+  }
+};
+
+/** Narrow an unknown parsed value to a ServerLock, or undefined if it is not one. */
+const toServerLock: (value: unknown) => ServerLock | undefined = (value: unknown): ServerLock | undefined => {
+  if (typeof value !== "object" || value === null) {return undefined;}
+  const pid: unknown = "pid" in value ? value.pid : undefined;
+  const port: unknown = "port" in value ? value.port : undefined;
+  const startedAt: unknown = "startedAt" in value ? value.startedAt : undefined;
+  if (typeof pid !== "number" || typeof port !== "number" || typeof startedAt !== "number") {return undefined;}
+  return { pid, port, startedAt };
+};
+
+/** Read an existing lock file, or undefined if missing/corrupt. */
+const readLock: (lockPath: string) => ServerLock | undefined = (lockPath: string): ServerLock | undefined => {
+  if (!fs.existsSync(lockPath)) {return undefined;}
+  try {
+    return toServerLock(JSON.parse(fs.readFileSync(lockPath, "utf8")));
+  } catch {
+    return undefined;
+  }
+};
+
+/** Write our own lock, creating the state directory if needed. */
+const writeLock: (lockPath: string, lock: ServerLock) => Result<LockOutcome, string> = (
+  lockPath: string,
+  lock: ServerLock,
+): Result<LockOutcome, string> => {
+  try {
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify(lock));
+    return success({ kind: "acquired", path: lockPath });
+  } catch (e: unknown) {
+    return error(`Failed to write lock file ${lockPath}: ${String(e)}`);
+  }
+};
+
+/**
+ * Try to claim this workspace folder for the current process. Returns `busy` if a
+ * LIVE Too Many Cooks process already holds the lock; otherwise overwrites any
+ * stale lock (left by a crash / `kill -9`) and returns `acquired`.
+ * [SERVER-SINGLE-INSTANCE]
+ */
+export const acquireServerLock: (
+  lockPath: string,
+  port: number,
+  startedAt: number,
+) => Result<LockOutcome, string> = (
+  lockPath: string,
+  port: number,
+  startedAt: number,
+): Result<LockOutcome, string> => {
+  const existing: ServerLock | undefined = readLock(lockPath);
+  if (existing !== undefined && isPidAlive(existing.pid)) {
+    return success({ kind: "busy", path: lockPath, existing });
+  }
+  return writeLock(lockPath, { pid: process.pid, port, startedAt });
+};
+
+/** Remove the lock on shutdown — but only if it still records OUR pid. [SERVER-LOCKFILE] */
+export const releaseServerLock: (lockPath: string) => void = (lockPath: string): void => {
+  const existing: ServerLock | undefined = readLock(lockPath);
+  if (existing?.pid === process.pid) {
+    try {
+      fs.rmSync(lockPath, { force: true });
+    } catch {
+      // Best-effort cleanup: a missing lock on the way out is not an error.
+    }
+  }
+};

--- a/too-many-cooks/packages/too-many-cooks/test/published_package_e2e_test.ts
+++ b/too-many-cooks/packages/too-many-cooks/test/published_package_e2e_test.ts
@@ -60,8 +60,9 @@ const PRISMA_RUNTIME_REL_PATH: string = "node_modules/prisma/package.json";
 /** Workspace-relative path to the SQLite database file. */
 const DB_REL_PATH: string = ".too_many_cooks/data.db";
 
-/** Port the spawned server listens on. Fixed; if it clashes the bin's
- *  built-in port-takeover kicks in (the suite kills it anyway). */
+/** Port the spawned server listens on. Fixed; the suite boots one server at a
+ *  time and kills it before the next, so the port is free each boot. The server
+ *  never takes over a busy port ([SERVER-NO-KILL]) — it would step aside. */
 const PORT: number = 4067;
 
 /** Polling tuning for the readiness probe. */

--- a/too-many-cooks/packages/too-many-cooks/test/server_no_cross_kill_test.ts
+++ b/too-many-cooks/packages/too-many-cooks/test/server_no_cross_kill_test.ts
@@ -1,0 +1,140 @@
+/// [SERVER-NO-KILL] — Too Many Cooks must NEVER kill the process that owns a
+/// port it wants. Issue #33: a second window ran `lsof -ti :4040` + `kill -9`
+/// and terminated a DIFFERENT project's process.
+///
+/// This test puts a foreign (non-TMC) process on the target port, then starts
+/// the TMC server on that same port. The TMC server MUST leave the foreign
+/// process completely alone and step aside itself.
+
+import { describe, it, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+
+import { SERVER_BINARY, SERVER_NODE_ARGS } from "../src/config.js";
+
+// ============================================================
+// Constants
+// ============================================================
+
+const PORT_FOREIGN = 4070;
+const TMP_PREFIX = "/tmp/tmc-nocrosskill-";
+const STEP_ASIDE_TIMEOUT_MS = 10000;
+const READY_TIMEOUT_MS = 10000;
+const STILL_RUNNING = "still-running";
+const SENTINEL_READY_MARKER = "LISTENING";
+
+/// A bare TCP listener that binds the port the same way the server does
+/// (no explicit host → Node's default address), prints a readiness marker,
+/// then stays alive. It is NOT a Too Many Cooks server.
+const SENTINEL_SCRIPT =
+  "const s=require('net').createServer(c=>{c.destroy();});" +
+  "s.on('error',()=>process.exit(2));" +
+  "s.listen(Number(process.argv[1]),()=>{process.stdout.write('LISTENING\\n');});" +
+  "setInterval(()=>{},1000000);";
+
+// ============================================================
+// Helpers
+// ============================================================
+
+const spawnSentinel = (port: number): ChildProcess =>
+  spawn("node", ["-e", SENTINEL_SCRIPT, String(port)], {
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+
+const waitForMarker = async (
+  proc: ChildProcess,
+  marker: string,
+  timeoutMs: number,
+): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const timer = setTimeout((): void => {
+      reject(new Error(`Sentinel did not emit "${marker}" within ${String(timeoutMs)}ms`));
+    }, timeoutMs);
+    proc.stdout?.on("data", (chunk: Buffer): void => {
+      if (chunk.toString().includes(marker)) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+  });
+
+const spawnServerOnPort = (port: number): {
+  readonly proc: ChildProcess;
+  readonly workspace: string;
+  readonly stderr: string[];
+} => {
+  const workspace = mkdtempSync(TMP_PREFIX);
+  const stderr: string[] = [];
+  const proc = spawn("node", [...SERVER_NODE_ARGS, SERVER_BINARY], {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, TMC_PORT: String(port), TMC_WORKSPACE: workspace },
+  });
+  proc.stderr?.on("data", (chunk: Buffer): void => { stderr.push(chunk.toString()); });
+  return { proc, workspace, stderr };
+};
+
+const waitForExit = async (
+  proc: ChildProcess,
+  timeoutMs: number,
+): Promise<number | null | typeof STILL_RUNNING> =>
+  new Promise((resolve) => {
+    if (proc.exitCode !== null) { resolve(proc.exitCode); return; }
+    const timer = setTimeout((): void => { resolve(STILL_RUNNING); }, timeoutMs);
+    proc.once("exit", (code: number | null): void => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+
+// ============================================================
+// Test
+// ============================================================
+
+describe("server never kills a foreign process holding its port", () => {
+  let sentinel: ChildProcess;
+  let server: ChildProcess;
+  let workspace: string;
+  let sentinelExited = false;
+
+  after(() => {
+    server.kill("SIGKILL");
+    sentinel.kill("SIGKILL");
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it("foreign port owner survives and the TMC server steps aside", async () => {
+    // Park a foreign (non-TMC) process on the port.
+    sentinel = spawnSentinel(PORT_FOREIGN);
+    sentinel.once("exit", (): void => { sentinelExited = true; });
+    await waitForMarker(sentinel, SENTINEL_READY_MARKER, READY_TIMEOUT_MS);
+
+    // Start the TMC server on the SAME port.
+    const spawned = spawnServerOnPort(PORT_FOREIGN);
+    server = spawned.proc;
+    workspace = spawned.workspace;
+
+    // The TMC server MUST give up — never kill the foreign owner.
+    const exitResult = await waitForExit(server, STEP_ASIDE_TIMEOUT_MS);
+
+    // THE KEY ASSERTION: the foreign process MUST still be alive.
+    assert.strictEqual(
+      sentinelExited,
+      false,
+      `Foreign process on port ${String(PORT_FOREIGN)} MUST NOT be killed by the TMC server. ` +
+      `Server stderr:\n${spawned.stderr.join("")}`,
+    );
+
+    // And the TMC server itself MUST step aside rather than run.
+    assert.notStrictEqual(
+      exitResult,
+      STILL_RUNNING,
+      "TMC server MUST exit when the port is held by another process, not keep running",
+    );
+    assert.notStrictEqual(
+      exitResult,
+      0,
+      "TMC server MUST exit with a non-zero code when it cannot bind the port",
+    );
+  });
+});

--- a/too-many-cooks/packages/too-many-cooks/test/server_single_instance_test.ts
+++ b/too-many-cooks/packages/too-many-cooks/test/server_single_instance_test.ts
@@ -1,0 +1,152 @@
+/// [SERVER-SINGLE-INSTANCE] / [SERVER-LOCKFILE] — there is exactly ONE Too Many
+/// Cooks server per workspace folder. A second server started in a folder that
+/// already has a running server MUST refuse to start (even on a different port,
+/// because both would share the same `.too_many_cooks/data.db`).
+///
+/// Issue #33: nothing stopped two servers in the same folder from running, which
+/// corrupts the shared coordination database.
+
+import { describe, it, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { SERVER_BINARY, SERVER_NODE_ARGS } from "../src/config.js";
+
+// ============================================================
+// Constants
+// ============================================================
+
+const PORT_FIRST = 4071;
+const PORT_SECOND = 4072;
+const MAX_POLL_ATTEMPTS = 50;
+const POLL_INTERVAL_MS = 200;
+const ADMIN_STATUS_PATH = "/admin/status";
+const TMP_PREFIX = "/tmp/tmc-singleinstance-";
+const STATUS_OK = 200;
+const REFUSE_TIMEOUT_MS = 10000;
+const STILL_RUNNING = "still-running";
+const LOCK_REL_PATH = ".too_many_cooks/server.lock";
+const ALREADY_RUNNING_MARKER = "already running in this folder";
+
+// ============================================================
+// Helpers
+// ============================================================
+
+const buildBaseUrl = (port: number): string => `http://localhost:${String(port)}`;
+
+/// Spawn the server bound to an EXPLICIT workspace so two instances can share one.
+const spawnInWorkspace = (port: number, workspace: string): {
+  readonly proc: ChildProcess;
+  readonly stderr: string[];
+} => {
+  const stderr: string[] = [];
+  const proc = spawn("node", [...SERVER_NODE_ARGS, SERVER_BINARY], {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, TMC_PORT: String(port), TMC_WORKSPACE: workspace },
+  });
+  proc.stderr?.on("data", (chunk: Buffer): void => { stderr.push(chunk.toString()); });
+  return { proc, stderr };
+};
+
+const pollUntilReady = async (port: number): Promise<void> => {
+  const url = `${buildBaseUrl(port)}${ADMIN_STATUS_PATH}`;
+  for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {
+    try {
+      const r = await fetch(url);
+      if (r.ok) { return; }
+    } catch {
+      // Not ready yet
+    }
+    if (i === MAX_POLL_ATTEMPTS - 1) {
+      throw new Error(`Server on port ${String(port)} failed to start`);
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+};
+
+const fetchStatus = async (port: number): Promise<number> => {
+  const response = await fetch(`${buildBaseUrl(port)}${ADMIN_STATUS_PATH}`);
+  return response.status;
+};
+
+const waitForExit = async (
+  proc: ChildProcess,
+  timeoutMs: number,
+): Promise<number | null | typeof STILL_RUNNING> =>
+  new Promise((resolve) => {
+    if (proc.exitCode !== null) { resolve(proc.exitCode); return; }
+    const timer = setTimeout((): void => { resolve(STILL_RUNNING); }, timeoutMs);
+    proc.once("exit", (code: number | null): void => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+
+// ============================================================
+// Test
+// ============================================================
+
+describe("only one server may run per workspace folder", () => {
+  let firstProc: ChildProcess | undefined;
+  let secondProc: ChildProcess | undefined;
+  let workspace: string | undefined;
+
+  after(() => {
+    secondProc?.kill("SIGKILL");
+    firstProc?.kill("SIGKILL");
+    if (workspace !== undefined) { rmSync(workspace, { recursive: true, force: true }); }
+  });
+
+  it("a second server in the same folder refuses to start, leaving the first alive", async () => {
+    const ws = mkdtempSync(TMP_PREFIX);
+    workspace = ws;
+
+    // First server claims the folder.
+    const first = spawnInWorkspace(PORT_FIRST, ws);
+    firstProc = first.proc;
+    await pollUntilReady(PORT_FIRST);
+    assert.strictEqual(
+      await fetchStatus(PORT_FIRST),
+      STATUS_OK,
+      "First server MUST be alive",
+    );
+
+    // The lock file proves all state lives in the folder ([SERVER-LOCKFILE]).
+    assert.ok(
+      existsSync(join(ws, LOCK_REL_PATH)),
+      `First server MUST write a lock file at ${LOCK_REL_PATH}`,
+    );
+
+    // Second server, SAME folder, DIFFERENT port (so there is no port clash —
+    // the folder lock is the only thing that can stop it).
+    const second = spawnInWorkspace(PORT_SECOND, ws);
+    secondProc = second.proc;
+
+    const exitResult = await waitForExit(second.proc, REFUSE_TIMEOUT_MS);
+    assert.notStrictEqual(
+      exitResult,
+      STILL_RUNNING,
+      "Second server in the same folder MUST refuse to start and exit, not keep running",
+    );
+    assert.notStrictEqual(
+      exitResult,
+      0,
+      "Second server MUST exit with a non-zero code when the folder is already in use",
+    );
+
+    const secondStderr = second.stderr.join("").toLowerCase();
+    assert.ok(
+      secondStderr.includes(ALREADY_RUNNING_MARKER),
+      `Second server MUST explain it refused because TMC is "${ALREADY_RUNNING_MARKER}". Got:\n${second.stderr.join("")}`,
+    );
+
+    // First server MUST be entirely unaffected.
+    assert.strictEqual(
+      await fetchStatus(PORT_FIRST),
+      STATUS_OK,
+      "First server MUST still be alive after the second refused to start",
+    );
+  });
+});

--- a/too-many-cooks/packages/too-many-cooks/test/server_startup_test.ts
+++ b/too-many-cooks/packages/too-many-cooks/test/server_startup_test.ts
@@ -1,5 +1,6 @@
 /// Server startup integration tests - spawn real server processes,
-/// verify startup behavior, custom port, port takeover, and
+/// verify startup behavior, custom port, no-cross-kill step-aside on
+/// port conflict ([SERVER-NO-KILL]/[SERVER-PORT-CONFLICT]), and
 /// initial /admin/status response shape.
 
 import { describe, it, after } from "node:test";
@@ -15,13 +16,19 @@ import { SERVER_BINARY, SERVER_NODE_ARGS } from "../src/config.js";
 
 const PORT_STATUS_RESPONDS = 4050;
 const PORT_CUSTOM = 4051;
-const PORT_TAKEOVER = 4052;
+const PORT_CONFLICT = 4052;
 const PORT_INITIAL_STATE = 4053;
 const MAX_POLL_ATTEMPTS = 30;
 const POLL_INTERVAL_MS = 200;
 const ADMIN_STATUS_PATH = "/admin/status";
 const TMP_PREFIX = "/tmp/tmc-startup-";
 const STATUS_OK = 200;
+
+/** How long to wait for the losing server to step aside and exit. */
+const STEP_ASIDE_TIMEOUT_MS = 10000;
+
+/** Sentinel returned by waitForExit when the process never exits. */
+const STILL_RUNNING = "still-running";
 const EMPTY_ARRAY_LENGTH = 0;
 const AGENTS_FIELD = "agents";
 const LOCKS_FIELD = "locks";
@@ -93,6 +100,20 @@ const cleanup = (proc: ChildProcess, workspace: string): void => {
   rmSync(workspace, { recursive: true, force: true });
 };
 
+/** Wait for a process to exit, returning its exit code, or STILL_RUNNING on timeout. */
+const waitForExit = async (
+  proc: ChildProcess,
+  timeoutMs: number,
+): Promise<number | null | typeof STILL_RUNNING> =>
+  new Promise((resolve) => {
+    if (proc.exitCode !== null) { resolve(proc.exitCode); return; }
+    const timer = setTimeout((): void => { resolve(STILL_RUNNING); }, timeoutMs);
+    proc.once("exit", (code: number | null): void => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+
 // ============================================================
 // Tests
 // ============================================================
@@ -141,59 +162,60 @@ describe("server starts on custom port via TMC_PORT", () => {
   });
 });
 
-describe("server kills existing process on same port", () => {
+// [SERVER-NO-KILL] / [SERVER-PORT-CONFLICT]: a second server (a DIFFERENT
+// project) that finds the port occupied MUST step aside cleanly — it must
+// NEVER kill the process that owns the port. Issue #33.
+describe("server does NOT kill an existing server on the same port — it steps aside", () => {
   let firstProc: ChildProcess;
   let secondProc: ChildProcess;
   let firstWorkspace: string;
   let secondWorkspace: string;
 
   after(() => {
-    // Second server should be the live one; kill both to be safe
     secondProc.kill();
     firstProc.kill();
     rmSync(firstWorkspace, { recursive: true, force: true });
     rmSync(secondWorkspace, { recursive: true, force: true });
   });
 
-  it("second server takes over port from first", async () => {
-    // Start first server
-    const first = spawnOnPort(PORT_TAKEOVER);
+  it("loser of the port race exits non-zero while the owner stays alive", async () => {
+    // Start the first server (project A) — it owns the port.
+    const first = spawnOnPort(PORT_CONFLICT);
     firstProc = first.proc;
     firstWorkspace = first.workspace;
-    await pollUntilReady(PORT_TAKEOVER);
+    await pollUntilReady(PORT_CONFLICT);
 
-    // Verify first is alive
-    const beforeStatus = await fetchStatus(PORT_TAKEOVER);
+    const beforeStatus = await fetchStatus(PORT_CONFLICT);
     assert.strictEqual(
       beforeStatus.status,
       STATUS_OK,
-      "First server MUST be alive before takeover",
+      "First server MUST be alive before the second starts",
     );
 
-    // Start second server on same port — it should kill the first
-    const second = spawnOnPort(PORT_TAKEOVER);
+    // Start the second server (project B, different folder) on the SAME port.
+    const second = spawnOnPort(PORT_CONFLICT);
     secondProc = second.proc;
     secondWorkspace = second.workspace;
-    await pollUntilReady(PORT_TAKEOVER);
 
-    // Verify second server is responding
-    const afterStatus = await fetchStatus(PORT_TAKEOVER);
+    // The second server MUST give up rather than kill the first.
+    const exitResult = await waitForExit(secondProc, STEP_ASIDE_TIMEOUT_MS);
+    assert.notStrictEqual(
+      exitResult,
+      STILL_RUNNING,
+      "Second server MUST step aside and exit on EADDRINUSE, not keep running by killing the owner",
+    );
+    assert.notStrictEqual(
+      exitResult,
+      0,
+      "Second server MUST exit with a non-zero code when the port is already in use",
+    );
+
+    // The first server (project A) MUST be completely untouched.
+    const afterStatus = await fetchStatus(PORT_CONFLICT);
     assert.strictEqual(
       afterStatus.status,
       STATUS_OK,
-      "Second server MUST respond after taking over port",
-    );
-
-    // Verify the second server has a fresh state (empty arrays)
-    assert.strictEqual(
-      afterStatus.body.agents.length,
-      EMPTY_ARRAY_LENGTH,
-      "Second server MUST have empty agents (fresh DB)",
-    );
-    assert.strictEqual(
-      afterStatus.body.locks.length,
-      EMPTY_ARRAY_LENGTH,
-      "Second server MUST have empty locks (fresh DB)",
+      "First server MUST still be alive — the second MUST NOT have killed it",
     );
   });
 });

--- a/too-many-cooks/readme.md
+++ b/too-many-cooks/readme.md
@@ -90,6 +90,16 @@ The server starts on **port 4040** and exposes:
 TMC_PORT=5050 TMC_WORKSPACE=/path/to/project too-many-cooks
 ```
 
+<h3 style="font-weight:700;letter-spacing:-0.02em;">One server per folder — never kills anything</h3>
+
+Too Many Cooks isolates by **workspace folder**, and it **never** kills or signals another process:
+
+- **All state lives in `${workspace}/.too_many_cooks/`** — the database, the logs, and the single-instance lock. No other instance can touch it.
+- **If a server is already running in this folder, the second start exits immediately** with `Too Many Cooks is already running in this folder` (it would otherwise corrupt the shared database).
+- **If the port is already in use, the server steps aside cleanly** (a graceful `EADDRINUSE` exit) — it does **not** run `lsof`/`kill -9` against whatever owns the port. To run two folders at once, give each its own `TMC_PORT`.
+
+This is why two VS Code windows on two different projects can no longer collide: neither one can kill the other's server.
+
 <br>
 
 <h2 style="font-weight:700;letter-spacing:-0.02em;padding-bottom:0.5rem;border-bottom:2px solid #c46d3b;">Connect Your Agent</h2>

--- a/website/src/docs/getting-started.md
+++ b/website/src/docs/getting-started.md
@@ -45,6 +45,8 @@ To target a specific workspace:
 TMC_WORKSPACE=/path/to/your/project too-many-cooks
 ```
 
+> **One server per folder.** Too Many Cooks isolates by workspace folder and never kills another process. If a server is already running in this folder it refuses to start a second one; if the port is already taken it steps aside cleanly rather than killing the owner. To run two projects at once, give each its own `TMC_PORT`. All state (database, logs, lock) lives in that folder's `.too_many_cooks/`.
+
 ## Upgrade
 
 If you installed globally, update all TMC packages to the latest version:

--- a/website/src/docs/how-it-works.md
+++ b/website/src/docs/how-it-works.md
@@ -36,6 +36,16 @@ Agents register once per connection. The server stores the agent name and key in
 | `messages` | Inter-agent messages |
 | `plans` | Agent goals and current tasks |
 
+## Process isolation — one server per folder, never kills anything
+
+Isolation is by **workspace folder**. A Too Many Cooks server never kills, signals, or takes over another process:
+
+- **All state lives in `${workspace}/.too_many_cooks/`** — the database, the logs, and a single-instance lock file. No other instance can read or corrupt it.
+- **A second server in the same folder refuses to start**, with `Too Many Cooks is already running in this folder` — because both would otherwise share one database.
+- **If the port is already taken, the server steps aside cleanly** instead of killing the owner. To run two folders at once, give each its own `TMC_PORT`.
+
+This is what lets two editor windows on two different projects run side by side without one silently killing the other's server.
+
 ## Why HTTP, not stdio
 
 Stdio spawns an isolated process per agent. Agents cannot see each other's events. HTTP gives one shared process where the notification emitter works across all connected agents.


### PR DESCRIPTION
Closes #33.

## The bug
Two VSCode windows on two different projects both started the local MCP server and collided on the shared port `4040`. The second server ran `lsof -ti :4040` + `kill -9` and **terminated the first window's (a different project's) server**. The killed process then EPIPE-looped on its broken stderr into a multi-gigabyte log that could crash the editor. There was also nothing stopping two servers from running in the **same** folder against one `data.db`.

## The design (per-folder isolation; never kill anything)
A Too Many Cooks server now **never** kills, signals, or takes over another process. Isolation is by **workspace folder**:

- **`[SERVER-NO-KILL]`** — removed `killExistingProcess` (`lsof` + `kill -9`) entirely. The only use of `process.kill` is the **signal-0 liveness probe** (sends no signal).
- **`[SERVER-SINGLE-INSTANCE]`** — a second server in the same folder refuses to start: *"Too Many Cooks is already running in this folder"*. Guarded by a per-folder `.too_many_cooks/server.lock` (**`[SERVER-LOCKFILE]`**, stale-lock safe via the liveness probe).
- **`[SERVER-PORT-CONFLICT]`** — a busy port now produces a clean non-zero `EADDRINUSE` exit (an `app.listen` `'error'` handler) instead of killing the owner. Run a distinct `TMC_PORT` per folder to use several at once.
- **`[SERVER-STATE-ISOLATION]`** — all per-workspace state (db, logs, lock) lives under `${workspace}/.too_many_cooks/`.
- **`[SERVER-EPIPE]`** — `stdout`/`stderr` `'error'` listeners + an EPIPE guard in the `uncaughtException` handler, so a dead pipe can never loop into the logger.

The single-instance lock lives in the **local server package** (not shared `core`), so the published bin never depends on a newer `core` release.

## Docs first
`docs/spec.md` gains a **"Server Lifecycle & Process Isolation"** section (the spec IDs above). README, CHANGELOG, and the website docs (`how-it-works`, `getting-started`) updated to make the no-kill / per-folder / step-aside / state-in-`.too_many_cooks` rules crystal clear.

## Tests (written failing-first, per TDD)
- `server_no_cross_kill_test.ts` — a foreign (non-TMC) process holding the port **survives**; the TMC server steps aside.
- `server_single_instance_test.ts` — a second server in the same folder is **refused**; the first stays alive; the lock file exists.
- `server_startup_test.ts` — the old *"server kills existing process on same port"* block (which encoded the bug as desired) is rewritten: the loser steps aside, the owner stays alive.

Each was confirmed to **fail because of the bug** before the fix (kill logs / missing lock), then pass after. Full MCP server suite: **365 pass / 0 fail**, including the published-package tarball E2E (9/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)