### PR TITLE
Dependabot staging-branch pattern (route bumps to dependabot-upgrades, auto-merge)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,76 @@
+# agent-pmo:795a9c2
+# Dependabot — supply-chain defense without PR spam, and without burning CI on
+# `main` for routine bumps ([GITHUB-DEPENDABOT]).
+#
+# How this kills the spam:
+#   * VERSION updates -> `target-branch: dependabot-upgrades`. Every routine bump
+#     PR is opened against the long-lived `dependabot-upgrades` STAGING branch,
+#     never against main. ci.yml / codeql.yml only trigger on
+#     `pull_request: [main]` (the filter matches the PR *base*), so these staging
+#     PRs run NO build/test/CodeQL. They are auto-merged into the staging branch
+#     by .github/workflows/dependabot-automerge.yml. When you want the batch in
+#     main you open ONE `dependabot-upgrades -> main` PR and CI runs exactly once.
+#   * SECURITY updates -> still raised automatically against `main`, untouched by
+#     this file. Per GitHub docs, `target-branch` only redirects *version*
+#     updates; security updates always use the repo's default branch. So a real
+#     CVE still opens a PR against main where you see it and CI runs. That channel
+#     is governed by the repo's "Dependabot security updates" setting, NOT here.
+#   * groups with no `update-types` filter -> each ecosystem collapses ALL bumps
+#     (patch, minor AND major) into ONE grouped PR per run. Majors no longer need
+#     their own review PR because nothing reaches main unattended — review happens
+#     once, at the consolidation PR.
+#   * interval: weekly -> one grouped PR per ecosystem each week, not fifty.
+#
+# SHA-pinned actions are a prime supply-chain target ([SWR-SEC-ACTION-PINNING]),
+# so github-actions is kept current here too.
+#
+# Only the ecosystems this repo actually uses are configured:
+#   - github-actions: the workflow files under .github/
+#   - npm: the three Node projects (MCP server monorepo, VS Code extension, website)
+#   - pub: the Dart codegen toolkit
+#
+# REQUIREMENT: the `dependabot-upgrades` branch must exist. Cut it from main
+# AFTER this file + dependabot-automerge.yml are on main, so the staging branch
+# carries the auto-merge workflow (pull_request runs from the PR base ref).
+version: 2
+
+updates:
+  # GitHub Actions — pinned actions are a prime supply-chain target; keep current.
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: "dependabot-upgrades"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  # npm / Node — three independent projects, each with its own lockfile.
+  # One grouped PR per directory, every bump type collapsed in.
+  - package-ecosystem: npm
+    directories:
+      - /too-many-cooks
+      - /too_many_cooks_vscode_extension
+      - /website
+    target-branch: "dependabot-upgrades"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    groups:
+      npm:
+        patterns: ["*"]
+
+  # pub / Dart — the codegen toolkit (codegen/pubspec.yaml).
+  - package-ecosystem: pub
+    directory: /codegen
+    target-branch: "dependabot-upgrades"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    groups:
+      pub:
+        patterns: ["*"]

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,43 @@
+# agent-pmo:795a9c2
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot version-bump PRs INTO the `dependabot-upgrades` staging
+# branch so they never pile up for a human to clear ([GITHUB-DEPENDABOT]).
+#
+# Safe to merge unattended here: nothing reaches `main` this way. The full
+# build/test (ci.yml) + CodeQL (codeql.yml) gate the single
+# `dependabot-upgrades -> main` consolidation PR, which is where review and the
+# expensive matrix actually run. This job is a ~10-second merge bot, NOT the CI
+# pipeline.
+#
+# Lives at the repo root so it is present on `dependabot-upgrades` (which is cut
+# from main): `pull_request` runs the workflow from the PR base ref, so the
+# staging branch must carry this file for auto-merge to fire.
+on:
+  pull_request:
+    branches:
+      - dependabot-upgrades
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge into dependabot-upgrades
+    if: github.actor == 'dependabot[bot]'
+    # Deliberately the standard runner, NOT a larger/paid runner: a trivial merge
+    # bot should not consume CI minutes meant for the real build matrix.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Squash-merge the bump into the staging branch
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Prefer auto-merge (queues until mergeable); fall back to an immediate
+        # squash merge when the PR is already mergeable (no required checks on the
+        # staging branch, so GitHub may refuse to "enable" auto-merge).
+        run: |
+          gh pr merge --auto --squash --delete-branch "$PR_URL" \
+            || gh pr merge --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
Routine version bumps now target the long-lived `dependabot-upgrades` staging branch instead of `main`, so they run **zero CI**. `dependabot-automerge.yml` squash-merges them into staging unattended. Batches reach `main` via one consolidation PR where CI/CodeQL run once.

Matches the portfolio standard ([GITHUB-DEPENDABOT]) — same pattern as Basilisk.

After merge: cut `dependabot-upgrades` from main (so the staging branch carries the auto-merge workflow), then the 4 open dependabot PRs are re-targeted onto it.