### PR TITLE
Fix VSIX packaging: pin @types/vscode to ^1.85.0 (unblock release → v0.15.1)

### DIFF
--- a/too_many_cooks_vscode_extension/package-lock.json
+++ b/too_many_cooks_vscode_extension/package-lock.json
@@ -16,7 +16,7 @@
         "@types/eslint": "^9.6.1",
         "@types/mocha": "^10.0.6",
         "@types/node": "^25.9.3",
-        "@types/vscode": "^1.125.0",
+        "@types/vscode": "^1.85.0",
         "@typescript-eslint/eslint-plugin": "^8.61.1",
         "@typescript-eslint/parser": "^8.61.1",
         "@vscode/test-cli": "^0.0.12",

--- a/too_many_cooks_vscode_extension/package.json
+++ b/too_many_cooks_vscode_extension/package.json
@@ -309,7 +309,7 @@
     "@types/eslint": "^9.6.1",
     "@types/mocha": "^10.0.6",
     "@types/node": "^25.9.3",
-    "@types/vscode": "^1.125.0",
+    "@types/vscode": "^1.85.0",
     "@typescript-eslint/eslint-plugin": "^8.61.1",
     "@typescript-eslint/parser": "^8.61.1",
     "@vscode/test-cli": "^0.0.12",


### PR DESCRIPTION
# TLDR;

The v0.15.0 release VSIX build failed: `vsce package` rejects `@types/vscode ^1.125.0` being greater than `engines.vscode ^1.85.0`. This pins `@types/vscode` back to `^1.85.0` to unblock the release.

# Details

A dependabot bump pushed `@types/vscode` to `^1.125.0` while `engines.vscode` stayed `^1.85.0`. `vsce` requires `@types/vscode <= engines.vscode`. Pinning `@types/vscode` to `^1.85.0` (rather than bumping `engines`) keeps broad VS Code (>= 1.85) support; the extension still compiles against 1.85 types. CI's Build/Lint/Test never caught this because only the release runs `vsce package`.

npm `0.15.0` already published from the v0.15.0 run, so this ships as **v0.15.1** to complete the release (VSIX → Marketplace/Open VSX + GitHub release + Pages).

# How do the tests prove the changes work?

- `npm run compile` (tsc) passes against `@types/vscode ^1.85.0`.
- `npx @vscode/vsce@3.9.2 package` succeeds locally — the exact step that failed in CI — producing a valid VSIX (524 files).
- CI Build/Lint/Test + CodeQL re-run on this PR.
